### PR TITLE
Edit the file "qsharp_convert.py"

### DIFF
--- a/pytket/extensions/qsharp/qsharp_convert.py
+++ b/pytket/extensions/qsharp/qsharp_convert.py
@@ -116,10 +116,10 @@ def operation_body(c: Circuit, sim: bool = True) -> List[str]:
     if sim:
         lines.append("        ResetAll(q);")
     if n_c > 0:
-        rt= "["
-        for cb in range(n_c-1): 
-            rt = rt + "r{}".format(cb) +", "
-        rt = rt + "r{}".format(n_c-1) + "]"
+        rt = "["
+        for cb in range(n_c - 1):
+            rt = rt + "r{}".format(cb) + ", "
+        rt = rt + "r{}".format(n_c - 1) + "]"
         lines.append("        return {};".format(rt))
     else:
         lines.append("        return new Result[0];")

--- a/pytket/extensions/qsharp/qsharp_convert.py
+++ b/pytket/extensions/qsharp/qsharp_convert.py
@@ -86,7 +86,7 @@ def main_body(c: Circuit) -> Tuple[List[str], List[int]]:
         if cmd.op.type == OpType.Measure:
             cb = cmd.bits[0].index[0]
             measured_bits.append(cb)
-            lines.append("        set r w/= {} <- M(q[{}]);".format(cb, qbs[0]))
+            lines.append("        let r{} = M(q[{}]);".format(cb, qbs[0]))
         else:
             lines.append("        " + cmd_body(cmd.op, qbs) + ";")
 
@@ -97,10 +97,6 @@ def operation_body(c: Circuit, sim: bool = True) -> List[str]:
     lines = []
     n_q = c.n_qubits
     n_c = len(c.bits)
-    if n_c > 0:
-        lines.append("    mutable r = [" + ", ".join(["Zero"] * n_c) + "];")
-    else:
-        lines.append("    mutable r = new Result[0];")
 
     lines.append("    use q = Qubit[{}] {{".format(n_q))
     # devices don't support reset yet
@@ -112,14 +108,21 @@ def operation_body(c: Circuit, sim: bool = True) -> List[str]:
     all_bits = list(range(n_c))
     if meas_bits != all_bits:
         extra_meas_lines = [
-            "        set r w/= {} <- Zero;".format(cb)
+            "        set r{} = Zero;".format(cb)
             for cb in all_bits
             if cb not in meas_bits
         ]
         lines.extend(extra_meas_lines)
     if sim:
         lines.append("        ResetAll(q);")
-    lines.append("        return r;")
+    if n_c > 0:
+        rt= "["
+        for cb in range(n_c-1): 
+            rt = rt + "r{}".format(cb) +", "
+        rt = rt + "r{}".format(n_c-1) + "]"
+        lines.append("        return {};".format(rt))
+    else:
+        lines.append("        return new Result[0];")
     lines.append("    }")
     return lines
 

--- a/pytket/extensions/qsharp/qsharp_convert.py
+++ b/pytket/extensions/qsharp/qsharp_convert.py
@@ -108,7 +108,7 @@ def operation_body(c: Circuit, sim: bool = True) -> List[str]:
     all_bits = list(range(n_c))
     if meas_bits != all_bits:
         extra_meas_lines = [
-            "        set r{} = Zero;".format(cb)
+            "        let r{} = Zero;".format(cb)
             for cb in all_bits
             if cb not in meas_bits
         ]


### PR DESCRIPTION
Edit the file "qsharp_convert.py" for solving an issue on Rigetti devices and simulator. Reason of the cause of the issue is that Rigetti devices and simulator doesn't support "mutable", which create multiple classical bits.
Remark: An issue on IonQ devices and simulator haven't been solved. If we create a qsharp circuit without any gate operation and execute the circuit on IonQ device or simulator, we have an error.  IonQ devices and simulator doesn't support a qsharp circuit without any gate operation.