### PR TITLE
add examples submitting to QTM devices

### DIFF
--- a/examples/Quantinuum Circuit Submissions via Azure Quantum and pytket-qsharp.ipynb
+++ b/examples/Quantinuum Circuit Submissions via Azure Quantum and pytket-qsharp.ipynb
@@ -1,0 +1,1193 @@
+{
+ "cells": [
+  {
+   "attachments": {
+    "Quantinuum%20Logos_primary_blue_small.svg": {
+     "image/svg+xml": [
+      "PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiIHN0YW5kYWxvbmU9Im5vIj8+CjwhLS0gQ3JlYXRlZCB3aXRoIElua3NjYXBlIChodHRwOi8vd3d3Lmlua3NjYXBlLm9yZy8pIC0tPgoKPHN2ZwogICB2ZXJzaW9uPSIxLjEiCiAgIGlkPSJzdmc5IgogICB3aWR0aD0iMTMwLjA5ODYyIgogICBoZWlnaHQ9Ijc1LjAwMDA2OSIKICAgdmlld0JveD0iMCAwIDEzMC4wOTg2MSA3NS4wMDAwNzQiCiAgIHNvZGlwb2RpOmRvY25hbWU9IlF1YW50aW51dW0gTG9nb3NfcHJpbWFyeV9ibHVlLnN2ZyIKICAgaW5rc2NhcGU6dmVyc2lvbj0iMS4xLjIgKGI4ZTI1YmU4MzMsIDIwMjItMDItMDUpIgogICB4bWxuczppbmtzY2FwZT0iaHR0cDovL3d3dy5pbmtzY2FwZS5vcmcvbmFtZXNwYWNlcy9pbmtzY2FwZSIKICAgeG1sbnM6c29kaXBvZGk9Imh0dHA6Ly9zb2RpcG9kaS5zb3VyY2Vmb3JnZS5uZXQvRFREL3NvZGlwb2RpLTAuZHRkIgogICB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciCiAgIHhtbG5zOnN2Zz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciPgogIDxkZWZzCiAgICAgaWQ9ImRlZnMxMyIgLz4KICA8c29kaXBvZGk6bmFtZWR2aWV3CiAgICAgaWQ9Im5hbWVkdmlldzExIgogICAgIHBhZ2Vjb2xvcj0iI2ZmZmZmZiIKICAgICBib3JkZXJjb2xvcj0iIzY2NjY2NiIKICAgICBib3JkZXJvcGFjaXR5PSIxLjAiCiAgICAgaW5rc2NhcGU6cGFnZXNoYWRvdz0iMiIKICAgICBpbmtzY2FwZTpwYWdlb3BhY2l0eT0iMC4wIgogICAgIGlua3NjYXBlOnBhZ2VjaGVja2VyYm9hcmQ9IjAiCiAgICAgc2hvd2dyaWQ9ImZhbHNlIgogICAgIGZpdC1tYXJnaW4tbGVmdD0iMCIKICAgICBmaXQtbWFyZ2luLWJvdHRvbT0iMCIKICAgICBmaXQtbWFyZ2luLXJpZ2h0PSIwIgogICAgIGZpdC1tYXJnaW4tdG9wPSIwIgogICAgIGlua3NjYXBlOnpvb209IjEuNjQ2NTQ3NCIKICAgICBpbmtzY2FwZTpjeD0iLTI5LjQ1NTU3NSIKICAgICBpbmtzY2FwZTpjeT0iMTM1LjczODU4IgogICAgIGlua3NjYXBlOndpbmRvdy13aWR0aD0iMTkyMCIKICAgICBpbmtzY2FwZTp3aW5kb3ctaGVpZ2h0PSIxMjAxIgogICAgIGlua3NjYXBlOndpbmRvdy14PSItOSIKICAgICBpbmtzY2FwZTp3aW5kb3cteT0iLTkiCiAgICAgaW5rc2NhcGU6d2luZG93LW1heGltaXplZD0iMSIKICAgICBpbmtzY2FwZTpjdXJyZW50LWxheWVyPSJnMTUiCiAgICAgd2lkdGg9IjM0NS42MTQxNHB4IgogICAgIHVuaXRzPSJtbSIKICAgICBzY2FsZS14PSIxIiAvPgogIDxnCiAgICAgaW5rc2NhcGU6Z3JvdXBtb2RlPSJsYXllciIKICAgICBpbmtzY2FwZTpsYWJlbD0iSW1hZ2UiCiAgICAgaWQ9ImcxNSIKICAgICB0cmFuc2Zvcm09InRyYW5zbGF0ZSgtMzIuOTUwNzIsLTMxLjgwMzE4MikiPgogICAgPHBhdGgKICAgICAgIHN0eWxlPSJmaWxsOiM3NDgwOTk7ZmlsbC1vcGFjaXR5OjE7c3Ryb2tlLXdpZHRoOjAuMTI0MDQ2IgogICAgICAgZD0ibSAzNy41NTAzNDEsMTA2LjcxMjE1IGMgLTEuNDAzNTg4LC0wLjI3ODMgLTMuMTE0OTU0LC0xLjQ4MzE1IC0zLjgyMzE1OSwtMi42OTE2IC0xLjA2NzMzNCwtMS44MjEyNyAtMS4wMzAzMzQsLTQuNDQwNzc5IDAuMDg2NTUsLTYuMTI2OTYxIDEuODA2ODQ2LC0yLjcyNzgzNiA1LjQxMDAwNSwtMy40NTIxMDUgOC4xNDQ0MjQsLTEuNjM3MDk1IDEuMjI5MjY0LDAuODE1OTM0IDIuMDk2NjU1LDIuMTY3NjAxIDIuNDA4NjQ3LDMuNzUzNDE2IDAuMTU3OTY0LDAuODAyOTMgMC4xMDAwNTEsMi4wNzEwNSAtMC4xMjExNTgsMi42NTI4NyAtMC4xMjEzNjgsMC4zMTkyMiAtMC4xNzEwNzIsMC4zMzcwOSAtMC45Mzc1MzIsMC4zMzcwOSAtMC40NDUxNTEsMCAtMC44MDkzNjksLTAuMDMxNCAtMC44MDkzNjksLTAuMDY5NyAwLC0wLjAzODMgMC4wOTA5MiwtMC4zNDc3MSAwLjIwMjA0OCwtMC42ODc0NiAwLjI5MjI0OCwtMC44OTM0OSAwLjE4NTMxNywtMi4yMDg1MyAtMC4yNDg5MzgsLTMuMDYxNDY5IC0wLjQ0MjQyMSwtMC44Njg5ODkgLTEuMTg0OTAyLC0xLjU5MTU3NyAtMi4wNDM1MzYsLTEuOTg4ODA4IC0xLjAwNjAxNywtMC40NjU0MTMgLTIuMzk3MzU1LC0wLjQ2Nzg1MSAtMy4zODI0ODEsLTAuMDA2IC0wLjk3OTM5NywwLjQ1OTIyNiAtMS42NTMxODgsMS4xMTU5ODcgLTIuMTIyMDc0LDIuMDY4NDI4IC0wLjM1MDkyMiwwLjcxMjgyMyAtMC40MDE1NDUsMC45Mzg0NTkgLTAuMzkzNTk4LDEuNzU0MzA5IDAuMDE3MDksMS43NTM3MyAwLjg2NTc3OSwzLjExOTU2IDIuMzc5MTc4LDMuODI4ODggMC43MDMxMzUsMC4zMjk1NiAwLjc0MDYwMSwwLjMzMzE1IDQuMTIwODUsMC4zOTQ2IGwgMy40MTEyNjMsMC4wNjIgdiAwLjc0NDI3IDAuNzQ0MjggbCAtMy4xNjMxNzEsMC4wMTg1IGMgLTEuNzM5NzQ1LDAuMDEwMSAtMy40MDgzMTksLTAuMDMwMiAtMy43MDc5MzksLTAuMDg5NiB6IG0gMTQuMDA5Mzc0LC0yLjIzNTE5IGMgLTEuMjM1NDUxLC0wLjI0MjE3IC0yLjUxODUwOSwtMS4xNjQ5NyAtMy4xNzQ4MjksLTIuMjgzMzkgLTAuNTQwMTA4LC0wLjkyMDM4IC0wLjY3NjIxNywtMS43ODQzNCAtMC42NzYyMTcsLTQuMjkyMzc2IDAsLTIuNTU0MjA0IC0wLjAyODEsLTIuNDY4MTI2IDAuODA2Mjk5LC0yLjQ2ODEyNiAwLjgzNjgwMiwwIDAuODA2MDIzLC0wLjA5ODQ1IDAuODA5MDI0LDIuNTg3MjI2IDAuMDAzMSwyLjcxNDMzNiAwLjA5NjE1LDMuMTIzMTI2IDAuOTAzNjI4LDMuOTY3MDY2IDAuNjcyMDAzLDAuNzAyMzUgMS4yNjQxODcsMC45NDQzNSAyLjMxODg0MSwwLjk0NzYxIDAuNzkyOTg0LDAuMDAyIDEuMDE1NDEsLTAuMDQ3MSAxLjUwNjQ4OSwtMC4zMzU4MSAwLjMxNjg4MiwtMC4xODYyOSAwLjczMDA0MSwtMC41MjEyMSAwLjkxODEzMywtMC43NDQyOCAwLjY3NTUwNCwtMC44MDExMiAwLjczMzc5OCwtMS4wNzkwNCAwLjgwMDU3MywtMy44MTY4NDggbCAwLjA2MjAzLC0yLjU0Mjk0NiAwLjU5ODg1NCwtMC4wMzgxNyBjIDAuOTQ0MDIxLC0wLjA2MDIzIDAuOTUxNzIsLTAuMDQxNCAwLjk1MTcyLDIuMzI1NDYgMCwxLjEzODk1MiAtMC4wNjA2OCwyLjQwMjA0NCAtMC4xMzQ4MzEsMi44MDY4NjQgLTAuMzU5MDUxLDEuOTYwMDQgLTEuOTE3MDM3LDMuNTM1NTYgLTMuODYwNzU1LDMuOTA0MTcgLTAuNzIzNzI3LDAuMTM3MjUgLTEuMDYwNDc3LDAuMTM0MjMgLTEuODI4OTUzLC0wLjAxNjQgeiBtIDc0LjczMjA2NSwtMC4wMzY1IGMgLTEuNDMxMzgsLTAuMzQ4MDkgLTIuNjQ4MDUsLTEuMzM4MzggLTMuMjY3MzEsLTIuNjU5NCAtMC4zMjY2OSwtMC42OTY4NyAtMC4zMzAwMiwtMC43MzIxNCAtMC4zMzAwMiwtMy40OTUwMTUgdiAtMi43OTEwMzIgaCAwLjY4MjI1IDAuNjgyMjYgbCAwLjA2NTMsMi41NDI5MzkgYyAwLjA2MywyLjQ1NzM2OCAwLjA3NjQsMi41NjQ0MzggMC4zOTg4OCwzLjE4MTYyOCAwLjgwNjAyLDEuNTQyODYgMi42MTMwMywyLjE5MzMyIDQuMTMwMzQsMS40ODY3NyAwLjczNzQ0LC0wLjM0MzQgMS42MTQyMiwtMS4yODQ5NiAxLjc5MTc3LC0xLjkyNDE3IDAuMDY4NiwtMC4yNDcxNiAwLjEyNTE0LC0xLjQ4OTE3NyAwLjEyNTUxLC0yLjc2MDA0NiA3LjVlLTQsLTIuNjMyODExIC0wLjAwMSwtMi42MjYxODEgMC45NTI0MSwtMi41NjUzMjYgbCAwLjU5ODg2LDAuMDM4MTggdiAyLjcyOTAxNCAyLjcyOTAwOCBsIC0wLjM5Mzc3LDAuODMxMiBjIC0wLjY2MzMyLDEuNDAwMTggLTEuNjkyNDgsMi4yNDMyOSAtMy4yMjU4NCwyLjY0MjY3IC0wLjgzNDU4LDAuMjE3MzkgLTEuMzU5MTQsMC4yMjA2MSAtMi4yMTA1NSwwLjAxMzYgeiBtIDEzLjM5Njk3LDAgYyAtMS40MzEzOCwtMC4zNDgwOSAtMi42NDgwNiwtMS4zMzgzOCAtMy4yNjczMiwtMi42NTk0IC0wLjMyNjY5LC0wLjY5Njg3IC0wLjMzMDAyLC0wLjczMjE0IC0wLjMzMDAyLC0zLjQ5NTAxNSB2IC0yLjc5MTAzMiBoIDAuNjgyMjUgMC42ODIyNiBsIDAuMDY1MywyLjU0MjkzOSBjIDAuMDYzLDIuNDU3MzY4IDAuMDc2NCwyLjU2NDQzOCAwLjM5ODg3LDMuMTgxNjI4IDEuMDU0NzUsMi4wMTg5OCAzLjYxODI5LDIuMzY4NDggNS4yMDQ5NiwwLjcwOTY0IDAuNzc5NDUsLTAuODE0OTEgMC44NDMzNiwtMS4xMDM2NSAwLjg0MzM2LC0zLjgxMDA2NiAwLC0yLjc0MDU3OSAtMC4wMDYsLTIuNzIzNDQxIDAuOTUxNzIsLTIuNjYyMzQ2IGwgMC41OTg4NSwwLjAzODE4IHYgMi43MjkwMTQgYyAwLDIuNzI0Mjg4IDAsMi43MzAyODggLTAuMzQ0NDgsMy40NjQ2MTggLTAuNjc4ODQsMS40NDk1MyAtMS43Mzk4OCwyLjM0MjE5IC0zLjI0NzksMi43MzI0MyAtMC44NjIyMSwwLjIyMzExIC0xLjM4MTUxLDAuMjI3NjEgLTIuMjM3NzcsMC4wMTk0IHogbSAtODAuMDcxNjY5LC0wLjI0NzY5IGMgMCwtMC4xNzkzMSA0LjEyNzg0NiwtOC4zMTYxMjYgNC4zNjE4MzksLTguNTk4MDc0IDAuMTQ1ODYzLC0wLjE3NTc0OCAxLjkxNTUyNSwtMC4yMzAyODggMi4xNjYyNjUsLTAuMDY2NzUgMC4xMzMzODUsMC4wODY5OSA0LjUxMTk4Niw4LjU4MTkxNCA0LjUxMTk4Niw4Ljc1MzY5NCAwLDAuMDQ1NSAtMC4zNjU0MjgsMC4wODI3IC0wLjgxMjA2NywwLjA4MjcgLTAuNzc5ODcsMCAtMC44MjA0NDQsLTAuMDE1MiAtMS4wMjMzNzksLTAuMzg0MzYgLTAuMTE2MjIsLTAuMjExMzkgLTAuMzEzNzk0LC0wLjUxOTM1IC0wLjQzOTA1MywtMC42ODQzNSBsIC0wLjIyNzc0MSwtMC4zMDAwMSAtMy4xMjE1LDAuMDMzMSAtMy4xMjE1LDAuMDMzMSAtMC4zNDksMC42NTEyNCAtMC4zNDg5OTksMC42NTEyNCBoIC0wLjc5ODQyNiBjIC0wLjU5Njk3NCwwIC0wLjc5ODQyNSwtMC4wNDMzIC0wLjc5ODQyNSwtMC4xNzE1NCB6IG0gNy41NjY4MDMsLTIuODA0MTcgYyAwLjE1NTk4LC0wLjA5OTYgMC4wMTU1NSwtMC40NTU0IC0wLjg2ODMyMSwtMi4xOTk5MjIgLTAuNTc5OTE1LC0xLjE0NDU3NiAtMS4xMjY3NTIsLTIuMDgxMDUgLTEuMjE1MTk4LC0yLjA4MTA1IC0wLjA4ODQ0LDAgLTAuNjQ2NDM0LDAuOTM3MTY0IC0xLjIzOTk3OSwyLjA4MjU4OCAtMC45MDA4NDUsMS43Mzg0NjQgLTEuMDQ4NTAyLDIuMTAxOTg0IC0wLjg5MzU4LDIuMTk5OTE0IDAuMjQzMzI4LDAuMTUzODMgMy45NzYwMDMsMC4xNTI0NiA0LjIxNzA3OCwtMC4wMDIgeiBtIDYuOTc2MDE5LC0xLjQ1ODkyOCAwLjAzMjU3LC00LjQzNDY0NCAwLjgzODA3NCwtMC4wMzY2OCAwLjgzODA3LC0wLjAzNjY4IDMuNTAwNTU4LDMuNDA2OTQgYyAxLjkyNTMwNSwxLjg3MzgyMiAzLjU0Mzc2LDMuMzgwMjQyIDMuNTk2NTczLDMuMzQ3NjAyIDAuMDUyODEsLTAuMDMyNiAwLjA5NjAxLC0xLjUwMDU0IDAuMDk2MDEsLTMuMjYyMDIgMCwtMy42MjM5NTIgLTAuMDI4NjUsLTMuNTE5ODc1IDAuOTUxNzE1LC0zLjQ1NzMzMiBsIDAuNTk4ODUzLDAuMDM4MTcgMC4wMzI2Miw0LjQzNDY0NCAwLjAzMjU1LDQuNDM0NjM4IC0xLjA4Njk2OSwwLjAwMiAtMS4wODY5NywwLjAwMSAtMy4yOTE3NTMsLTMuMzczODcgYyAtMi4xNDA3OTIsLTIuMTk0MjgyIC0zLjM0NDM4NywtMy4zNDE0MzEgLTMuNDQyMjc1LC0zLjI4MDkzNiAtMC4xMTE4NTUsMC4wNjkxNSAtMC4xNTA1MjIsMC45MzU1NTkgLTAuMTUwNTIyLDMuMzcyOTI2IHYgMy4yNzk4OSBoIC0wLjc0NTg0MiAtMC43NDU4NDIgeiBtIDE4LjE0MjIzMiw0LjI4NTgxOCBjIC0wLjAzMzA4LC0wLjA4ODcgLTAuMDc0MjUsLTEuNzI0MjcgLTAuMDkxNTQsLTMuNjM0NTggbCAtMC4wMzE0MywtMy40NzMyODIgLTIuMDgzNjA4LC0wLjAzNDA1IC0yLjA4MzYwNywtMC4wMzQwNSAwLjAzNjksLTAuNzcyMjYxIDAuMDM2ODMsLTAuNzcyMjY5IGggNC45NjE4NDIgNC45NjE4MzQgbCAwLjAzNjksMC43NzIyNjkgMC4wMzY4MywwLjc3MjI2MSAtMi4wODM2MDgsMC4wMzQwNSAtMi4wODM2MTUsMC4wMzQwNSAtMC4wNjIwMiwzLjU5NzMzMiAtMC4wNjIwMywzLjU5NzMzIC0wLjcxNDc2NiwwLjAzNzMgYyAtMC41MDA5MTksMC4wMjYxIC0wLjczMjc0NCwtMC4wMTEgLTAuNzc0ODQ5LC0wLjEyNDA1IHogbSA5LjY0NDA2NSwtNC4yODU4MTggMC4wMzI2LC00LjQzNDY0NCBoIDAuNjgyMjUgMC42ODIyNSBsIDAuMDMyNiw0LjQzNDY0NCAwLjAzMjYsNC40MzQ2NDggaCAtMC43NDc0MSAtMC43NDc0MSB6IG0gNi4yMDIyOSwwIDAuMDMyNiwtNC40MzQ2NDQgMC44Mzk1MywtMC4wMzY3NSAwLjgzOTUyLC0wLjAzNjc1IDMuNTAyMDksMy40MDQ5ODIgYyAxLjkyNjE0LDEuODcyNzUgMy41NDM5NCwzLjM3OTE4IDMuNTk1MTEsMy4zNDc2NCAwLjA1MTEsLTAuMDMxNiAwLjA5MywtMS40OTg1NSAwLjA5MywtMy4yNjAwMjUgMCwtMy42MjM5NiAtMC4wMjg2LC0zLjUxOTg3NSAwLjk1MTczLC0zLjQ1NzMzOSBsIDAuNTk4ODUsMC4wMzgxOCAwLjAzMjYsNC40MzQ2NDMgMC4wMzI2LDQuNDM0NjQxIGggLTEuMDc2NTUgLTEuMDc2NTYgbCAtMy4zMDM0NCwtMy4zNzIxMyBjIC0yLjEyODI2LC0yLjE3MjUxMiAtMy4zNTY1NCwtMy4zMzkzMjYgLTMuNDUyNywtMy4yNzk5MDQgLTAuMTEwMiwwLjA2ODEgLTAuMTQ5MjQsMC45NTAxMzkgLTAuMTQ5MjQsMy4zNzIxMzQgdiAzLjI3OTkgaCAtMC43NDU4NSAtMC43NDU4NCB6IG0gNDEuMzA3MzEsMCAwLjAzMjUsLTQuNDM0NjQ0IDEuMTE2NDEsLTAuMDMxNTggYyAwLjYxNDAzLC0wLjAxNzQgMS4xODM2NiwwLjAxMjIzIDEuMjY1ODUsMC4wNjU4NSAwLjA4MjIsMC4wNTM1NSAxLjA2NDIyLDEuNzQyNDE4IDIuMTgyMywzLjc1Mjk1MyAxLjExODA5LDIuMDEwNTE5IDIuMTAzMjIsMy42NTU1MDkgMi4xODkyMSwzLjY1NTUwOSAwLjA4NiwwIDEuMDQwMTUsLTEuNjA4ODEgMi4xMjAzOSwtMy41NzUxMDkgMS4wODAyNCwtMS45NjYzMTUgMi4wMzAyOCwtMy42NTQ4OSAyLjExMTIsLTMuNzUyMzkgMC4yMDM3NiwtMC4yNDU1MjEgMi4yNTczNSwtMC4yNTE3OTggMi40NjAwOCwtMC4wMDc1IDAuMTAwNTYsMC4xMjExNjIgMC4xMzE1NCwxLjM5MDM4MiAwLjEwODIzLDQuNDM0NjM5IGwgLTAuMDMyNyw0LjI2NDkgLTAuNzc1MjksMC4wMzcgLTAuNzc1MjgsMC4wMzcgdiAtMy4zNDc4NCBjIDAsLTEuODQxMzEyIC0wLjA0OTUsLTMuMzc4NDMxIC0wLjExLC0zLjQxNTgxOSAtMC4xNjE4NSwtMC4xMDAwMzUgLTAuMjE3NTMsLTAuMDA5OSAtMS44NzI2OSwzLjAzMDQzOSAtMC44MzU2OSwxLjUzNTA3IC0xLjY1MzI5LDMuMDAwMzYgLTEuODE2ODksMy4yNTYyMSBsIC0wLjI5NzQ2LDAuNDY1MTYgaCAtMS4xNTMzNyAtMS4xNTMzOCBsIC0xLjg5MzgzLC0zLjQxMTI2IGMgLTEuMDQxNjIsLTEuODc2MTg3IC0xLjkzOTI2LC0zLjQxMTI1OSAtMS45OTQ3NywtMy40MTEyNTkgLTAuMjE2NDYsMCAtMC4yNTE1MiwwLjUwMjgwMSAtMC4yNTE1MiwzLjYwNzQ3OSB2IDMuMjE1MDQgSCAxNTAuMTY5IDE0OS40MjMxNSBaIE0gOTQuMDMzNDY3LDc3LjE5NDg4IGMgLTAuNjE3NTI4LC0wLjA1MTAxIC0xLjc1MjU3MiwtMC4yMTMyMzkgLTIuNTIyMzI4LC0wLjM2MDUwOCAtNS43OTI2NDEsLTEuMTA4MjUgLTExLjMwMTM3MSwtNC43NjYwMjggLTE0LjU5NzgxMSwtOS42OTI4OTQgLTUuMjI3MjgyLC03LjgxMjcgLTQuNzk3MDU5LC0xOS4yMDM0OSAxLjAwNDYxNywtMjYuNTk4NzQ5IDAuNzI1NTUzLC0wLjkyNDg0NCAyLjA0MjY3MiwtMi4zMTI3NjkgMi4wNDI2NzIsLTIuMTUyNDc4IDAsMC4wMzkwNiAtMC4yMTYyNzQsMC41MzkzNTIgLTAuNDgwNjEyLDEuMTExNzUxIC0wLjYyNDg3MywxLjM1MzExNSAtMS4xODYzNDQsMy4xMjA1MTkgLTEuNDU2MzQ5LDQuNTg0Mjk0IC0wLjI4OTY5LDEuNTcwNTE3IC0wLjI5NTUwMSw0LjcxODM5IC0wLjAxMTU1LDYuMjcyODk1IDEuMzUwNDg4LDcuMzk0MDI4IDYuOTI3ODkxLDEzLjA2NTczMSAxNC40NzI3NzQsMTQuNzE3NDczIDEuMTQ3NTMyLDAuMjUxMjIgMS41NTU5ODIsMC4yNjAyNzEgMTMuNjgxNjcsMC4zMDMxMjkgbCAxMi40OTg4MywwLjA0NDE3IC0wLjAzMjMsNS45MTgxODMgLTAuMDMyMiw1LjkxODE4MiAtMTEuNzIyMzQsMC4wMTM2NCBjIC02LjQ0NzI5LDAuMDA3NSAtMTIuMjI3NTkyLC0wLjAyODEgLTEyLjg0NTEyLC0wLjA3OTEgeiBNIDExNC4xNDMyOCw2Mi41MzM4MzQgYyAtMC4wMjcxLC0wLjA4NzQ2IC0wLjA4MTEsLTAuODg0Njg0IC0wLjExOTk2LC0xLjc3MTYxMyAtMC4xNzM3NCwtMy45NjI5ODIgLTEuNTk4MzYsLTcuNTYyOTk5IC00LjE5Nzg1LC0xMC42MDc5NjMgLTIuNjQwNjQsLTMuMDkzMTUyIC02LjU5MDM2LC01LjMyMzg3MSAtMTAuODg1ODE4LC02LjE0ODA3MyAtMS43NTI5MzMsLTAuMzM2MzQ5IC01LjA4Mzg2NywtMC4zMTA4ODggLTYuNzgzODgsMC4wNTE4NSAtNC4wMjg5NTMsMC44NTk2ODggLTcuNTM1MDM1LDIuOTYzMTcxIC0xMC4wNjQ3OTMsNi4wMzgzOTggLTAuNTIzNTU5LDAuNjM2NDQ4IC0wLjk5OTU5LDEuMTExMDE1IC0xLjA1Nzg0OSwxLjA1NDU5NSAtMC40MDAxMTMsLTAuMzg3NDkyIC0wLjY4OTQ4NiwtMy45MjU0OTcgLTAuNDYxODE5LC01LjY0NjQ2OCAwLjcyNDQ0NCwtNS40NzYyNzIgMy43OTU3MzgsLTkuODA1ODk4IDguNjMwNzMyLC0xMi4xNjY3OTggMy4zOTMyNjcsLTEuNjU2OTEzIDcuODQyNzQ2LC0xLjk4OTgzIDEyLjE5MTgyNywtMC45MTIyMTEgOC40OTQ5NCwyLjEwNDg4MyAxNS4xNjEyMiw5LjE0NzIzNiAxNi45MjA4MiwxNy44NzUzOTcgMC4yNDI2NiwxLjIwMzY5OSAwLjI4MzUyLDEuNzg5NTAxIDAuMjg0MDEsNC4wNzI4OTggMy43ZS00LDEuNjU5NzcxIC0wLjA2MTMsMy4wMTgzNDYgLTAuMTYzMjMsMy41OTczMzUgLTAuMjM1NTEsMS4zMzc2MTEgLTAuODU2MjQsMy42OTc1MjQgLTEuMTA3ODMsNC4yMTE3NTYgbCAtMC4yMTUyNiwwLjQzOTk2OCAtMS40NTk5MSwwLjAzNDk2IGMgLTEuMTAzNDMsMC4wMjY0NCAtMS40NzE5NSwtMC4wMDM5IC0xLjUwOTE5LC0wLjEyNDA0NiB6IgogICAgICAgaWQ9InBhdGg0ODMiIC8+CiAgICA8cGF0aAogICAgICAgc3R5bGU9ImZpbGw6IzAwMDAwMDtzdHJva2Utd2lkdGg6MC4zMiIKICAgICAgIGlkPSJwYXRoMzQ1IgogICAgICAgZD0iIiAvPgogICAgPHBhdGgKICAgICAgIHN0eWxlPSJmaWxsOiMwMDAwMDA7c3Ryb2tlLXdpZHRoOjAuMzIiCiAgICAgICBpZD0icGF0aDExNyIKICAgICAgIGQ9IiIgLz4KICA8L2c+Cjwvc3ZnPgo="
+     ]
+    }
+   },
+   "cell_type": "markdown",
+   "id": "d791c1ee",
+   "metadata": {},
+   "source": [
+    "![Quantinuum%20Logos_primary_blue_small.svg](attachment:Quantinuum%20Logos_primary_blue_small.svg)"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "id": "c66d3480",
+   "metadata": {},
+   "source": [
+    "# Quantinuum Circuit Submissions via Azure Quantum and pytket-qsharp\n",
+    "\n",
+    "This notebook contains basic circuit submission examples to Quantinuum systems via `pytket` and `pytket-qsharp`, an extension that allows `pytket` circuits to be executed on simulators and resource estimators via the Microsoft QDK.\n",
+    "\n",
+    "* [Installations](#installations)\n",
+    "* [What is TKET?](#tket)\n",
+    "* [Step by Step](#step-by-step)\n",
+    "    * [Circuit Preparation](#circuit-preparation)\n",
+    "    * [Select Device](#select-device)\n",
+    "    * [Circuit Compilation](#circuit-compilation)\n",
+    "    * [Circuit Cost](#circuit-cost)\n",
+    "    * [Run the Circuit](#run-circuit)\n",
+    "    * [Retrieve Results](#retrieve-results)\n",
+    "    * [Save Results](#save-results)\n",
+    "    * [Analyze Results](#analyze-results)\n",
+    "    * [Cancel Jobs](#cancel-jobs)\n",
+    "* [Additional Features](#additional-features)\n",
+    "    * [Extended Circuit Compilation](#circuit-compilation-extended)\n",
+    "    * [Parametrized Circuits](#parametrized-circuits)\n",
+    "    * [Conditional Gates](#conditional-gates)"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "id": "24dcf574",
+   "metadata": {},
+   "source": [
+    "## Installations <a class=\"anchor\" id=\"installations\"></a>\n",
+    "\n",
+    "In order to run this notebook, you'll need to install a few packages into your local environment related to the [Microsoft QDK](https://learn.microsoft.com/en-us/azure/quantum/install-overview-qdk?tabs=tabid-vscode%2Ctabid-conda). For additional information or troubleshooting with the following installations, see: [Use Q# and Python with Jupyter Notebooks](https://learn.microsoft.com/en-us/azure/quantum/install-overview-qdk?tabs=tabid-vscode%2Ctabid-dotnetcli#use-q-and-python-with-jupyter-notebooks). If you prefer to use VS Code instead of Jupyter notebooks, see: [Using the Microsoft QDK with VS Code](https://learn.microsoft.com/en-us/azure/quantum/install-overview-qdk?tabs=tabid-vscode%2Ctabid-dotnetcli#use-q-and-python-with-visual-studio-and-visual-studio-code).\n",
+    "\n",
+    "1. Install the [.NET SDK](https://dotnet.microsoft.com/en-us/download). Make note of what version is recommended with the Microsoft QDK here: [Use Q# and Python with Jupyter Notebooks](https://learn.microsoft.com/en-us/azure/quantum/install-overview-qdk?tabs=tabid-vscode%2Ctabid-dotnetcli#use-q-and-python-with-jupyter-notebooks).\n",
+    "1. Install the `qsharp` python package: `pip install qsharp`.\n",
+    "1. Run `dotnet tool install -g Microsoft.Quantum.IQSharp` in a CLI after .NET is installed.\n",
+    "1. Run `dotnet iqsharp install`.\n",
+    "1. Install the `azure-quantum` python package: `pip install azure-quantum`.\n",
+    "1. Install [pytket-qsharp](https://cqcl.github.io/pytket-qsharp/api/api.html): `pip install pytket-qsharp`."
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "id": "d5cb08ab",
+   "metadata": {},
+   "source": [
+    "## What is TKET? <a class=\"anchor\" id=\"tket\"></a>\n",
+    "\n",
+    "The TKET framework (pronounced \"ticket\") is a software platform for the development and execution of gate-level quantum computation, providing state-of-the-art performance in circuit compilation. It was created and is maintained by Quantinuum. The toolset is designed to extract the most out of the available NISQ devices of today and is platform-agnostic. \n",
+    "\n",
+    "In python, the `pytket` packages is available.\n",
+    "\n",
+    "For more information on TKET, see the following links:\n",
+    "- [TKET user manual](https://cqcl.github.io/pytket/manual/manual_intro.html)\n",
+    "- [TKET overview and demo video](https://www.youtube.com/watch?v=yXKSpvgAtrk)\n",
+    "- [Quantum Compilation with TKET](https://calmaccq.github.io/tket_blog/tket_compilation.html)\n",
+    "\n",
+    "This notebook covers how to use `pytket` in conjunction with `pytket-qsharp` to submit to Quantinuum devices. The quantum compilation step is demonstrated, but for a full overview of quantum compilation with TKET, the last link above is recommended.\n",
+    "\n",
+    "See the links below for the `pytket` and `pytket-quantinuum` documentation:\n",
+    "- [pytket](https://cqcl.github.io/tket/pytket/api/index.html)\n",
+    "- [pytket-quantinuum](https://cqcl.github.io/pytket-quantinuum/api/index.html)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0aa29fd7",
+   "metadata": {},
+   "source": [
+    "## Step by Step <a class=\"anchor\" id=\"step-by-step\"></a>\n",
+    "\n",
+    "### Circuit Preparation <a class=\"anchor\" id=\"circuit-preparation\"></a>\n",
+    "\n",
+    "Create your circuit via the pytket python library. For details on getting started with `pytket`, see pytket's [Getting Started](https://cqcl.github.io/tket/pytket/api/getting_started.html) page.\n",
+    "\n",
+    "**Note**: `pytket` renders circuits in ZX-calculus notation. This can be toggled on and off by pressing the top left button in the circuit display."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "70007b79",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "\n",
+       "\n",
+       "\n",
+       "\n",
+       "\n",
+       "<iframe srcdoc=\"\n",
+       "&lt;!DOCTYPE html&gt;\n",
+       "&lt;html lang=&#34;en&#34;&gt;\n",
+       "&lt;head&gt;\n",
+       "    &lt;meta charset=&#34;UTF-8&#34;&gt;\n",
+       "    &lt;script type=&#34;application/javascript&#34; src=&#34;https://cdn.jsdelivr.net/npm/vue@3&#34;&gt;&lt;/script&gt;\n",
+       "    &lt;script type=&#34;application/javascript&#34; src=&#34;https://unpkg.com/pytket-circuit-renderer@0.3/dist/pytket-circuit-renderer.umd.js&#34;&gt;&lt;/script&gt;\n",
+       "    &lt;link rel=&#34;stylesheet&#34; href=&#34;https://unpkg.com/pytket-circuit-renderer@0.3/dist/pytket-circuit-renderer.css&#34;&gt;\n",
+       "&lt;/head&gt;\n",
+       "&lt;body&gt;\n",
+       "    &lt;div id=&#34;circuit-display-vue-container-b624027f-ff21-4083-83a2-1be2521854f7&#34; class=&#34;pytket-circuit-display-container&#34;&gt;\n",
+       "        &lt;div style=&#34;display: none&#34;&gt;\n",
+       "            &lt;div id=&#34;circuit-json-to-display&#34;&gt;{&#34;bits&#34;: [[&#34;c&#34;, [0]], [&#34;c&#34;, [1]]], &#34;commands&#34;: [{&#34;args&#34;: [[&#34;q&#34;, [0]]], &#34;op&#34;: {&#34;type&#34;: &#34;H&#34;}}, {&#34;args&#34;: [[&#34;q&#34;, [0]], [&#34;q&#34;, [1]]], &#34;op&#34;: {&#34;type&#34;: &#34;CX&#34;}}, {&#34;args&#34;: [[&#34;q&#34;, [0]], [&#34;c&#34;, [0]]], &#34;op&#34;: {&#34;type&#34;: &#34;Measure&#34;}}, {&#34;args&#34;: [[&#34;q&#34;, [1]], [&#34;c&#34;, [1]]], &#34;op&#34;: {&#34;type&#34;: &#34;Measure&#34;}}], &#34;created_qubits&#34;: [], &#34;discarded_qubits&#34;: [], &#34;implicit_permutation&#34;: [[[&#34;q&#34;, [0]], [&#34;q&#34;, [0]]], [[&#34;q&#34;, [1]], [&#34;q&#34;, [1]]]], &#34;name&#34;: &#34;Bell Test&#34;, &#34;phase&#34;: &#34;0.0&#34;, &#34;qubits&#34;: [[&#34;q&#34;, [0]], [&#34;q&#34;, [1]]]}&lt;/div&gt;\n",
+       "        &lt;/div&gt;\n",
+       "        &lt;circuit-display-container :circuit-element-str=&#34;&#39;#circuit-json-to-display&#39;&#34;&gt;&lt;/circuit-display-container&gt;\n",
+       "    &lt;/div&gt;\n",
+       "    &lt;script type=&#34;application/javascript&#34;&gt;\n",
+       "        const { createApp } = Vue;\n",
+       "        const circuitDisplayContainer = window[&#34;pytket-circuit-renderer&#34;].default;\n",
+       "        // Init variables to be shared between circuit display instances\n",
+       "        if (typeof window.pytketCircuitDisplays === &#34;undefined&#34;) {\n",
+       "            window.pytketCircuitDisplays = {};\n",
+       "        }\n",
+       "        const uid = &#34;b624027f-ff21-4083-83a2-1be2521854f7&#34;;\n",
+       "        // Create the root Vue component\n",
+       "        const app = createApp({\n",
+       "            delimiters: [&#39;[[#&#39;, &#39;#]]&#39;],\n",
+       "            components: { circuitDisplayContainer },\n",
+       "        })\n",
+       "        app.config.unwrapInjectedRef = true;\n",
+       "        app.mount(&#34;#circuit-display-vue-container-&#34;+uid);\n",
+       "        window.pytketCircuitDisplays[uid] = app;\n",
+       "    &lt;/script&gt;\n",
+       "&lt;/body&gt;\n",
+       "&lt;/html&gt;\n",
+       "\"\n",
+       "        width=\"100%\" height=\"200px\"\n",
+       "        style=\"border: none; outline: none; resize: vertical; overflow: auto\"></iframe>\n",
+       "\n"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "from pytket.circuit import Circuit, fresh_symbol\n",
+    "from pytket.circuit.display import render_circuit_jupyter\n",
+    "\n",
+    "# Set up Bell Test\n",
+    "circuit = Circuit(2, name=\"Bell Test\")\n",
+    "circuit.H(0)\n",
+    "circuit.CX(0, 1)\n",
+    "circuit.measure_all()\n",
+    "\n",
+    "render_circuit_jupyter(circuit)"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "id": "b5cc3705",
+   "metadata": {},
+   "source": [
+    "### Select Device <a class=\"anchor\" id=\"select-device\"></a>\n",
+    "\n",
+    "See the Azure Quantum [Quantinuum Provider](https://learn.microsoft.com/en-us/azure/quantum/provider-quantinuum) for information and target names for each of the H-Series systems available. The devices available to you will be listed under **Providers &rarr; Quantinuum** on the Azure portal.\n",
+    "\n",
+    "You will find the Resource ID and Location in the **Overview** tab in the Azure portal quantum workspace.\n",
+    "\n",
+    "Select a machine target and login to the Quantinuum API using your credentials. You will be prompted to login to your Azure Quantum account. For more information on the `AzureBackend`, see the pytket-qsharp [AzureBackend API](https://cqcl.github.io/pytket-qsharp/api/api.html#pytket.extensions.qsharp.AzureBackend)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "b488e6c4",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Preparing Q# environment...\n",
+      "."
+     ]
+    }
+   ],
+   "source": [
+    "from pytket.extensions.qsharp import AzureBackend\n",
+    "\n",
+    "machine = 'quantinuum.sim.h1-1sc'\n",
+    "resource_id = '/subscriptions/enter-your-info'\n",
+    "location = 'enter-your-region'\n",
+    "backend = AzureBackend(target_name=machine, resourceId=resource_id, location=location)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9130167b",
+   "metadata": {},
+   "source": [
+    "### Circuit Compilation <a class=\"anchor\" id=\"circuit-compilation\"></a>\n",
+    "\n",
+    "Circuits submitted to Quantinuum H-Series quantum computers and emulators are automatically run through TKET compilation passes for H-Series hardware. This enables circuits to be automatically optimized for H-Series systems and run more efficiently. \n",
+    "\n",
+    "More information on the specific compilation passes applied can be found on the `pytket-quantinuum` documentation, specifically the [Default Compilation](https://cqcl.github.io/pytket-quantinuum/api/index.html#default-compilation) section. In the H-Series software stack, the optimization level applied is set with the `tket-opt-level` parameter. **The default compilation setting for circuits submited to H-Series sytems is optimization level 2.**\n",
+    "\n",
+    "When using `pytket` before submitting to hardware, the `get_compiled_circuit` function performs the same compilation passes run after submission to Quantinuum systems. The advantage of using the function before submitting to H-Series hardware is to see exactly what circuit optimizations will be performed when submitted to hardware and determine if a different optimization level is desired. The `optimisation_level` parameter in the `get_compiled_circuit` function corresponds directly to the the level of optimisation after submitting to the H-Series systems and to the `tket-opt-level` parameter in the H-Series API. The default compilation for the `get_compiled_circuit` function is optimization level 2, the same as when submitting to the H-Series directly.\n",
+    "\n",
+    "Since the TKET compilation passes have been integrated into the H-Series stack, performing circuit optimizations is redundant before submitting to hardware, unless the user would like to see the optimizations applied before submitting. Given this, users may take 1 of 3 approaches when submitting jobs:\n",
+    "1. Use `optimisation_level=0` when running `get_compiled_circuit`, then submit the circuit using `process_circuits` knowing that the corresponding optimization level actually run will be 2. \n",
+    "2. Use the `get_compiled_circuit` function with the desired optimization level to observe the transformed circuit before submitting and then specify `tket-opt-level=None` in the `process_circuits` function when submitting, in order for the optimizations to be applied as desired.\n",
+    "3. If the user desires to have no optimizations applied, use `optimisation_level=0` in `get_compiled_circuit` and `tket-opt-level=None` in `process_circuits`. This should be specified in both functions.\n",
+    "\n",
+    "In this example, option 1 is illustrated, using `get_compiled_circuit` just to rebase the circuit and leaving the optimizations to be done in the H-Series stack."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "3974a8a2",
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "\n",
+       "\n",
+       "\n",
+       "\n",
+       "\n",
+       "<iframe srcdoc=\"\n",
+       "&lt;!DOCTYPE html&gt;\n",
+       "&lt;html lang=&#34;en&#34;&gt;\n",
+       "&lt;head&gt;\n",
+       "    &lt;meta charset=&#34;UTF-8&#34;&gt;\n",
+       "    &lt;script type=&#34;application/javascript&#34; src=&#34;https://cdn.jsdelivr.net/npm/vue@3&#34;&gt;&lt;/script&gt;\n",
+       "    &lt;script type=&#34;application/javascript&#34; src=&#34;https://unpkg.com/pytket-circuit-renderer@0.3/dist/pytket-circuit-renderer.umd.js&#34;&gt;&lt;/script&gt;\n",
+       "    &lt;link rel=&#34;stylesheet&#34; href=&#34;https://unpkg.com/pytket-circuit-renderer@0.3/dist/pytket-circuit-renderer.css&#34;&gt;\n",
+       "&lt;/head&gt;\n",
+       "&lt;body&gt;\n",
+       "    &lt;div id=&#34;circuit-display-vue-container-3afed8d3-b6cd-458d-b18d-334c981d42df&#34; class=&#34;pytket-circuit-display-container&#34;&gt;\n",
+       "        &lt;div style=&#34;display: none&#34;&gt;\n",
+       "            &lt;div id=&#34;circuit-json-to-display&#34;&gt;{&#34;bits&#34;: [[&#34;c&#34;, [0]], [&#34;c&#34;, [1]]], &#34;commands&#34;: [{&#34;args&#34;: [[&#34;q&#34;, [0]]], &#34;op&#34;: {&#34;type&#34;: &#34;H&#34;}}, {&#34;args&#34;: [[&#34;q&#34;, [0]], [&#34;q&#34;, [1]]], &#34;op&#34;: {&#34;type&#34;: &#34;CX&#34;}}, {&#34;args&#34;: [[&#34;q&#34;, [0]], [&#34;c&#34;, [0]]], &#34;op&#34;: {&#34;type&#34;: &#34;Measure&#34;}}, {&#34;args&#34;: [[&#34;q&#34;, [1]], [&#34;c&#34;, [1]]], &#34;op&#34;: {&#34;type&#34;: &#34;Measure&#34;}}], &#34;created_qubits&#34;: [], &#34;discarded_qubits&#34;: [], &#34;implicit_permutation&#34;: [[[&#34;q&#34;, [0]], [&#34;q&#34;, [0]]], [[&#34;q&#34;, [1]], [&#34;q&#34;, [1]]]], &#34;name&#34;: &#34;Bell Test&#34;, &#34;phase&#34;: &#34;0.0&#34;, &#34;qubits&#34;: [[&#34;q&#34;, [0]], [&#34;q&#34;, [1]]]}&lt;/div&gt;\n",
+       "        &lt;/div&gt;\n",
+       "        &lt;circuit-display-container :circuit-element-str=&#34;&#39;#circuit-json-to-display&#39;&#34;&gt;&lt;/circuit-display-container&gt;\n",
+       "    &lt;/div&gt;\n",
+       "    &lt;script type=&#34;application/javascript&#34;&gt;\n",
+       "        const { createApp } = Vue;\n",
+       "        const circuitDisplayContainer = window[&#34;pytket-circuit-renderer&#34;].default;\n",
+       "        // Init variables to be shared between circuit display instances\n",
+       "        if (typeof window.pytketCircuitDisplays === &#34;undefined&#34;) {\n",
+       "            window.pytketCircuitDisplays = {};\n",
+       "        }\n",
+       "        const uid = &#34;3afed8d3-b6cd-458d-b18d-334c981d42df&#34;;\n",
+       "        // Create the root Vue component\n",
+       "        const app = createApp({\n",
+       "            delimiters: [&#39;[[#&#39;, &#39;#]]&#39;],\n",
+       "            components: { circuitDisplayContainer },\n",
+       "        })\n",
+       "        app.config.unwrapInjectedRef = true;\n",
+       "        app.mount(&#34;#circuit-display-vue-container-&#34;+uid);\n",
+       "        window.pytketCircuitDisplays[uid] = app;\n",
+       "    &lt;/script&gt;\n",
+       "&lt;/body&gt;\n",
+       "&lt;/html&gt;\n",
+       "\"\n",
+       "        width=\"100%\" height=\"200px\"\n",
+       "        style=\"border: none; outline: none; resize: vertical; overflow: auto\"></iframe>\n",
+       "\n"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "compiled_circuit = backend.get_compiled_circuit(circuit, optimisation_level=0)\n",
+    "\n",
+    "render_circuit_jupyter(compiled_circuit)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "16f1e5f8",
+   "metadata": {},
+   "source": [
+    "### Run the Circuit <a class=\"anchor\" id=\"run-circuit\"></a>\n",
+    "\n",
+    "Now the circuit can be run on Quantinuum systems. \n",
+    "\n",
+    "**Note:** As described above, the TKET compilation optimization level 2 will be applied since no `tket-opt-level` is specified."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "d7f5d330",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Loading package Microsoft.Quantum.Providers.Honeywell and dependencies...\n",
+      "Active target is now quantinuum.sim.h1-1sc\n",
+      "Submitting TketCircuit to target quantinuum.sim.h1-1sc...\n",
+      "Job successfully submitted.\n",
+      "   Job name: Bell Test\n",
+      "   Job ID: 5c4c4e0d-efef-442b-99c7-4eb3898f8ba3\n",
+      "('5c4c4e0d-efef-442b-99c7-4eb3898f8ba3', 100, 'null')\n"
+     ]
+    }
+   ],
+   "source": [
+    "n_shots = 100\n",
+    "handle = backend.process_circuit(compiled_circuit, \n",
+    "                                 n_shots=n_shots)\n",
+    "print(handle)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ba22f504",
+   "metadata": {},
+   "source": [
+    "The status of a submitted job can be viewed at any time, indicating if a job has been submitted, queued, or is completed."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "5683b173",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CircuitStatus(status=<StatusEnum.COMPLETED: 'Circuit has completed. Results are ready.'>, message=\"{'id': '5c4c4e0d-efef-442b-99c7-4eb3898f8ba3', 'name': 'Bell Test', 'status': 'Succeeded', 'uri': 'https://portal.azure.com/#@microsoft.onmicrosoft.com/resource/subscriptions/f265e1a6-e359-4fca-842d-f90ecb910903/resourceGroups/QTM-Tests/providers/Microsoft.Quantum/Workspaces/megan-qtm-test-aq/job_management?microsoft_azure_quantum_jobid=5c4c4e0d-efef-442b-99c7-4eb3898f8ba3', 'provider': 'quantinuum', 'target': 'quantinuum.sim.h1-1sc', 'creation_time': '2023-02-10T22:35:24.1989514+00:00', 'begin_execution_time': '2023-02-10T22:35:27.483879+00:00', 'end_execution_time': '2023-02-10T22:35:27.484139+00:00', 'cost_estimate': '$0.00'}\", error_detail=None, completed_time=None, queued_time=None, submitted_time=None, running_time=None, cancelled_time=None, error_time=None, queue_position=None)\n"
+     ]
+    }
+   ],
+   "source": [
+    "status = backend.circuit_status(handle)\n",
+    "print(status)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ceef4545",
+   "metadata": {},
+   "source": [
+    "### Retrieve Results <a class=\"anchor\" id=\"retrieve-results\"></a>\n",
+    "\n",
+    "Once a job's status returns completed, results can be returned using the `get_result` function."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "7b65af16",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "BackendResult(q_bits={},c_bits={c[0]: 0, c[1]: 1},counts=Counter({OutcomeArray([[0]], dtype=uint8): 100}),shots=None,state=None,unitary=None,density_matrix=None)"
+      ]
+     },
+     "execution_count": 13,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "result = backend.get_result(handle)\n",
+    "\n",
+    "result"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f849e122",
+   "metadata": {},
+   "source": [
+    "### Save Results <a class=\"anchor\" id=\"save-results\"></a>\n",
+    "\n",
+    "Save the job results."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "id": "e340f8ac",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import json\n",
+    "\n",
+    "with open('pytket_example.json', 'w') as file:\n",
+    "    json.dump(result.to_dict(), file)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9e2a8c12",
+   "metadata": {},
+   "source": [
+    "Results can be loaded to their original format using `BackendResult.from_dict`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "id": "77d766e0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pytket.backends.backendresult import BackendResult\n",
+    "\n",
+    "with open('pytket_example.json') as file:\n",
+    "    data = json.load(file)\n",
+    "    \n",
+    "result = BackendResult.from_dict(data)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "id": "60456ed3",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "BackendResult(q_bits={},c_bits={c[0]: 0, c[1]: 1},counts=Counter({OutcomeArray([[0]], dtype=uint8): 100}),shots=None,state=None,unitary=None,density_matrix=None)"
+      ]
+     },
+     "execution_count": 16,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "result"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8e8ddbdc",
+   "metadata": {},
+   "source": [
+    "### Analyze Results <a class=\"anchor\" id=\"analyze-results\"></a>\n",
+    "\n",
+    "There are multiple options for analyzing results with pytket. A few examples are highlighted here. More can be seen at [Interpreting Results](https://cqcl.github.io/pytket/manual/manual_backend.html#interpreting-results)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "id": "b501499a",
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{(0, 0): 1.0}\n"
+     ]
+    }
+   ],
+   "source": [
+    "result = backend.get_result(handle)\n",
+    "print(result.get_distribution())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "id": "57857f13",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Counter({(0, 0): 100})\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(result.get_counts())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "id": "5bb5af4d",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{c[0]: 0, c[1]: 1}\n",
+      "{q[0]: 0, q[1]: 1}\n",
+      "{q[0]: c[0], q[1]: c[1]}\n"
+     ]
+    }
+   ],
+   "source": [
+    "# the map from bit to position in the measured state\n",
+    "print(compiled_circuit.bit_readout)\n",
+    "\n",
+    "# the map from qubit to position in the measured state\n",
+    "print(compiled_circuit.qubit_readout)\n",
+    "\n",
+    "# the map from qubits to the bits to which their measurement values were written\n",
+    "print(compiled_circuit.qubit_to_bit_map)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "646acbfb",
+   "metadata": {},
+   "source": [
+    "### Canceling jobs <a class=\"anchor\" id=\"cancel-jobs\"></a>\n",
+    "\n",
+    "Jobs that have been submitted can also be cancelled if needed."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a29682ac",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "backend.cancel(handle)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "25d637ac",
+   "metadata": {},
+   "source": [
+    "## Additional Features <a class=\"anchor\" id=\"additional-features\"></a>\n",
+    "\n",
+    "This section covers additional features available in `pytket`.\n",
+    "\n",
+    "* [Extended Circuit Compilation](#circuit-compilation-extended)\n",
+    "* [Parametrized Circuits](#parametrized-circuits)\n",
+    "* [Conditional Gates](#conditional-gates)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0b319a9d",
+   "metadata": {},
+   "source": [
+    "### Extended Circuit Compilation <a class=\"anchor\" id=\"circuit-compilation-extended\"></a>\n",
+    "\n",
+    "This section leverages the discussion in the [Circuit Compilation](#circuit-compilation) section to illsutrate how to turn TKET compilations on or off in the `process_circuit` function, specifically for options 2 and 3.\n",
+    "\n",
+    "For option 2 as described in [Circuit Compilation](#circuit-compilation), suppose a user explores the results of TKET compilation passes on a circuit and finds that `optimisation_level=1` is desirable. The submission below specifies this in the `get_compiled_circuit` function with optimization level 1. Because the circuit is optimized beforehand, the TKET optimization in the H-Series stack should be turned off. The value `tket-opt-level:None` turns off TKET optimization in the H-Series stack."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "id": "61eeac3f",
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Loading package Microsoft.Quantum.Providers.Honeywell and dependencies...\n",
+      "Active target is now quantinuum.sim.h1-1sc\n",
+      "Submitting TketCircuit to target quantinuum.sim.h1-1sc...\n",
+      "Job successfully submitted.\n",
+      "   Job name: Bell Test\n",
+      "   Job ID: 290bcb1b-2ea7-4f38-b68d-8b5f03e69c67\n",
+      "('290bcb1b-2ea7-4f38-b68d-8b5f03e69c67', 100, 'null')\n"
+     ]
+    }
+   ],
+   "source": [
+    "compiled_circuit = backend.get_compiled_circuit(circuit, optimisation_level=1)\n",
+    "\n",
+    "handle = backend.process_circuit(compiled_circuit, \n",
+    "                                 n_shots=n_shots,\n",
+    "                                 options={'tket-opt-level':None})\n",
+    "print(handle)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3c469530",
+   "metadata": {},
+   "source": [
+    "For option 3 as described in [Circuit Compilation](#circuit-compilation), suppose a user wants to turn off all optimizations in the stack, even simple single-qubit combinations done by the H-Series compiler. This can be done by setting `optimisation_level=0` in `get_compiled_circuit` and setting `tket-opt-level:None` in the `process_circuits` function."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "id": "04d99cca",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Loading package Microsoft.Quantum.Providers.Honeywell and dependencies...\n",
+      "Active target is now quantinuum.sim.h1-1sc\n",
+      "Submitting TketCircuit to target quantinuum.sim.h1-1sc...\n",
+      "Job successfully submitted.\n",
+      "   Job name: Bell Test\n",
+      "   Job ID: 84ab3511-5bb9-42ca-893f-3a8d2da9afe7\n",
+      "('84ab3511-5bb9-42ca-893f-3a8d2da9afe7', 100, 'null')\n"
+     ]
+    }
+   ],
+   "source": [
+    "compiled_circuit = backend.get_compiled_circuit(circuit, optimisation_level=0)\n",
+    "\n",
+    "handle = backend.process_circuit(compiled_circuit, \n",
+    "                                 n_shots=n_shots,\n",
+    "                                 options={'tket-opt-level': None})\n",
+    "print(handle)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "40888e0a",
+   "metadata": {},
+   "source": [
+    "### Parametrized Circuits <a class=\"anchor\" id=\"parametrized-circuits\"></a>\n",
+    "\n",
+    "Parametrized circuits are common in variational algorithms. Pytket supports parameters within circuits via symbols. For more information, see [Symbolic Circuits](https://cqcl.github.io/pytket/manual/manual_circuit.html?highlight=paramet#symbolic-circuits)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "id": "d8fbf383",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "\n",
+       "\n",
+       "\n",
+       "\n",
+       "\n",
+       "<iframe srcdoc=\"\n",
+       "&lt;!DOCTYPE html&gt;\n",
+       "&lt;html lang=&#34;en&#34;&gt;\n",
+       "&lt;head&gt;\n",
+       "    &lt;meta charset=&#34;UTF-8&#34;&gt;\n",
+       "    &lt;script type=&#34;application/javascript&#34; src=&#34;https://cdn.jsdelivr.net/npm/vue@3&#34;&gt;&lt;/script&gt;\n",
+       "    &lt;script type=&#34;application/javascript&#34; src=&#34;https://unpkg.com/pytket-circuit-renderer@0.3/dist/pytket-circuit-renderer.umd.js&#34;&gt;&lt;/script&gt;\n",
+       "    &lt;link rel=&#34;stylesheet&#34; href=&#34;https://unpkg.com/pytket-circuit-renderer@0.3/dist/pytket-circuit-renderer.css&#34;&gt;\n",
+       "&lt;/head&gt;\n",
+       "&lt;body&gt;\n",
+       "    &lt;div id=&#34;circuit-display-vue-container-259cf3f5-721b-4b60-b878-bbdeac3b628a&#34; class=&#34;pytket-circuit-display-container&#34;&gt;\n",
+       "        &lt;div style=&#34;display: none&#34;&gt;\n",
+       "            &lt;div id=&#34;circuit-json-to-display&#34;&gt;{&#34;bits&#34;: [], &#34;commands&#34;: [{&#34;args&#34;: [[&#34;q&#34;, [0]]], &#34;op&#34;: {&#34;type&#34;: &#34;X&#34;}}, {&#34;args&#34;: [[&#34;q&#34;, [0]], [&#34;q&#34;, [1]]], &#34;op&#34;: {&#34;type&#34;: &#34;CX&#34;}}, {&#34;args&#34;: [[&#34;q&#34;, [1]], [&#34;q&#34;, [2]]], &#34;op&#34;: {&#34;type&#34;: &#34;CX&#34;}}, {&#34;args&#34;: [[&#34;q&#34;, [2]]], &#34;op&#34;: {&#34;params&#34;: [&#34;a&#34;], &#34;type&#34;: &#34;Rz&#34;}}, {&#34;args&#34;: [[&#34;q&#34;, [1]], [&#34;q&#34;, [2]]], &#34;op&#34;: {&#34;type&#34;: &#34;CX&#34;}}, {&#34;args&#34;: [[&#34;q&#34;, [0]], [&#34;q&#34;, [1]]], &#34;op&#34;: {&#34;type&#34;: &#34;CX&#34;}}], &#34;created_qubits&#34;: [], &#34;discarded_qubits&#34;: [], &#34;implicit_permutation&#34;: [[[&#34;q&#34;, [0]], [&#34;q&#34;, [0]]], [[&#34;q&#34;, [1]], [&#34;q&#34;, [1]]], [[&#34;q&#34;, [2]], [&#34;q&#34;, [2]]]], &#34;name&#34;: &#34;Parametrized Circuit&#34;, &#34;phase&#34;: &#34;0.0&#34;, &#34;qubits&#34;: [[&#34;q&#34;, [0]], [&#34;q&#34;, [1]], [&#34;q&#34;, [2]]]}&lt;/div&gt;\n",
+       "        &lt;/div&gt;\n",
+       "        &lt;circuit-display-container :circuit-element-str=&#34;&#39;#circuit-json-to-display&#39;&#34;&gt;&lt;/circuit-display-container&gt;\n",
+       "    &lt;/div&gt;\n",
+       "    &lt;script type=&#34;application/javascript&#34;&gt;\n",
+       "        const { createApp } = Vue;\n",
+       "        const circuitDisplayContainer = window[&#34;pytket-circuit-renderer&#34;].default;\n",
+       "        // Init variables to be shared between circuit display instances\n",
+       "        if (typeof window.pytketCircuitDisplays === &#34;undefined&#34;) {\n",
+       "            window.pytketCircuitDisplays = {};\n",
+       "        }\n",
+       "        const uid = &#34;259cf3f5-721b-4b60-b878-bbdeac3b628a&#34;;\n",
+       "        // Create the root Vue component\n",
+       "        const app = createApp({\n",
+       "            delimiters: [&#39;[[#&#39;, &#39;#]]&#39;],\n",
+       "            components: { circuitDisplayContainer },\n",
+       "        })\n",
+       "        app.config.unwrapInjectedRef = true;\n",
+       "        app.mount(&#34;#circuit-display-vue-container-&#34;+uid);\n",
+       "        window.pytketCircuitDisplays[uid] = app;\n",
+       "    &lt;/script&gt;\n",
+       "&lt;/body&gt;\n",
+       "&lt;/html&gt;\n",
+       "\"\n",
+       "        width=\"100%\" height=\"200px\"\n",
+       "        style=\"border: none; outline: none; resize: vertical; overflow: auto\"></iframe>\n",
+       "\n"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "from pytket.circuit import fresh_symbol\n",
+    "\n",
+    "# Set up parametrized circuit\n",
+    "a = fresh_symbol('a')\n",
+    "circuit = Circuit(3, name=\"Parametrized Circuit\")\n",
+    "circuit.X(0)\n",
+    "circuit.CX(0,1).CX(1,2)\n",
+    "circuit.Rz(a, 2)\n",
+    "circuit.CX(1,2).CX(0,1)\n",
+    "\n",
+    "render_circuit_jupyter(circuit)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a2b1fd80",
+   "metadata": {},
+   "source": [
+    "Note the substitution of an actual value to the `a` variable below."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "id": "0f56040f",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "\n",
+       "\n",
+       "\n",
+       "\n",
+       "\n",
+       "<iframe srcdoc=\"\n",
+       "&lt;!DOCTYPE html&gt;\n",
+       "&lt;html lang=&#34;en&#34;&gt;\n",
+       "&lt;head&gt;\n",
+       "    &lt;meta charset=&#34;UTF-8&#34;&gt;\n",
+       "    &lt;script type=&#34;application/javascript&#34; src=&#34;https://cdn.jsdelivr.net/npm/vue@3&#34;&gt;&lt;/script&gt;\n",
+       "    &lt;script type=&#34;application/javascript&#34; src=&#34;https://unpkg.com/pytket-circuit-renderer@0.3/dist/pytket-circuit-renderer.umd.js&#34;&gt;&lt;/script&gt;\n",
+       "    &lt;link rel=&#34;stylesheet&#34; href=&#34;https://unpkg.com/pytket-circuit-renderer@0.3/dist/pytket-circuit-renderer.css&#34;&gt;\n",
+       "&lt;/head&gt;\n",
+       "&lt;body&gt;\n",
+       "    &lt;div id=&#34;circuit-display-vue-container-84651c42-23df-41b1-8b98-8f3e58dfe4a3&#34; class=&#34;pytket-circuit-display-container&#34;&gt;\n",
+       "        &lt;div style=&#34;display: none&#34;&gt;\n",
+       "            &lt;div id=&#34;circuit-json-to-display&#34;&gt;{&#34;bits&#34;: [[&#34;c&#34;, [0]], [&#34;c&#34;, [1]], [&#34;c&#34;, [2]]], &#34;commands&#34;: [{&#34;args&#34;: [[&#34;q&#34;, [1]], [&#34;c&#34;, [1]]], &#34;op&#34;: {&#34;type&#34;: &#34;Measure&#34;}}, {&#34;args&#34;: [[&#34;q&#34;, [2]], [&#34;c&#34;, [2]]], &#34;op&#34;: {&#34;type&#34;: &#34;Measure&#34;}}, {&#34;args&#34;: [[&#34;q&#34;, [0]]], &#34;op&#34;: {&#34;type&#34;: &#34;X&#34;}}, {&#34;args&#34;: [[&#34;q&#34;, [0]], [&#34;c&#34;, [0]]], &#34;op&#34;: {&#34;type&#34;: &#34;Measure&#34;}}], &#34;created_qubits&#34;: [[&#34;q&#34;, [0]], [&#34;q&#34;, [1]], [&#34;q&#34;, [2]]], &#34;discarded_qubits&#34;: [], &#34;implicit_permutation&#34;: [[[&#34;q&#34;, [0]], [&#34;q&#34;, [0]]], [[&#34;q&#34;, [1]], [&#34;q&#34;, [1]]], [[&#34;q&#34;, [2]], [&#34;q&#34;, [2]]]], &#34;name&#34;: &#34;Parametrized Circuit&#34;, &#34;phase&#34;: &#34;0.5&#34;, &#34;qubits&#34;: [[&#34;q&#34;, [0]], [&#34;q&#34;, [1]], [&#34;q&#34;, [2]]]}&lt;/div&gt;\n",
+       "        &lt;/div&gt;\n",
+       "        &lt;circuit-display-container :circuit-element-str=&#34;&#39;#circuit-json-to-display&#39;&#34;&gt;&lt;/circuit-display-container&gt;\n",
+       "    &lt;/div&gt;\n",
+       "    &lt;script type=&#34;application/javascript&#34;&gt;\n",
+       "        const { createApp } = Vue;\n",
+       "        const circuitDisplayContainer = window[&#34;pytket-circuit-renderer&#34;].default;\n",
+       "        // Init variables to be shared between circuit display instances\n",
+       "        if (typeof window.pytketCircuitDisplays === &#34;undefined&#34;) {\n",
+       "            window.pytketCircuitDisplays = {};\n",
+       "        }\n",
+       "        const uid = &#34;84651c42-23df-41b1-8b98-8f3e58dfe4a3&#34;;\n",
+       "        // Create the root Vue component\n",
+       "        const app = createApp({\n",
+       "            delimiters: [&#39;[[#&#39;, &#39;#]]&#39;],\n",
+       "            components: { circuitDisplayContainer },\n",
+       "        })\n",
+       "        app.config.unwrapInjectedRef = true;\n",
+       "        app.mount(&#34;#circuit-display-vue-container-&#34;+uid);\n",
+       "        window.pytketCircuitDisplays[uid] = app;\n",
+       "    &lt;/script&gt;\n",
+       "&lt;/body&gt;\n",
+       "&lt;/html&gt;\n",
+       "\"\n",
+       "        width=\"100%\" height=\"200px\"\n",
+       "        style=\"border: none; outline: none; resize: vertical; overflow: auto\"></iframe>\n",
+       "\n"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# Create a version of the circuit that utilizes a specific value for the variable a\n",
+    "simulation_circuit = circuit.copy()\n",
+    "simulation_circuit.measure_all()\n",
+    "simulation_circuit.symbol_substitution({a: -0.09})\n",
+    "\n",
+    "# Compile the circuit: this includes optimizing the gates and resynthesizing the circuit to Quantinuum's native gate set\n",
+    "compiled_circuit = backend.get_compiled_circuit(simulation_circuit)\n",
+    "\n",
+    "render_circuit_jupyter(compiled_circuit)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 25,
+   "id": "3668005a",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Loading package Microsoft.Quantum.Providers.Honeywell and dependencies...\n",
+      "Active target is now quantinuum.sim.h1-1sc\n",
+      "Submitting TketCircuit to target quantinuum.sim.h1-1sc...\n",
+      "Job successfully submitted.\n",
+      "   Job name: Parametrized Circuit\n",
+      "   Job ID: db8ff529-631d-4439-a82c-5774662e601f\n"
+     ]
+    }
+   ],
+   "source": [
+    "handle = backend.process_circuit(compiled_circuit, \n",
+    "                                 n_shots=n_shots)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 26,
+   "id": "7dab00aa",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CircuitStatus(status=<StatusEnum.SUBMITTED: 'Circuit has been submitted.'>, message=\"{'id': 'db8ff529-631d-4439-a82c-5774662e601f', 'name': 'Parametrized Circuit', 'status': 'Waiting', 'uri': 'https://portal.azure.com/#@microsoft.onmicrosoft.com/resource/subscriptions/f265e1a6-e359-4fca-842d-f90ecb910903/resourceGroups/QTM-Tests/providers/Microsoft.Quantum/Workspaces/megan-qtm-test-aq/job_management?microsoft_azure_quantum_jobid=db8ff529-631d-4439-a82c-5774662e601f', 'provider': 'quantinuum', 'target': 'quantinuum.sim.h1-1sc', 'creation_time': '2023-02-10T22:41:16.9506524+00:00', 'begin_execution_time': None, 'end_execution_time': None, 'cost_estimate': ''}\", error_detail=None, completed_time=None, queued_time=None, submitted_time=None, running_time=None, cancelled_time=None, error_time=None, queue_position=None)\n"
+     ]
+    }
+   ],
+   "source": [
+    "status = backend.circuit_status(handle)\n",
+    "print(status)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 27,
+   "id": "dee26625",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "BackendResult(q_bits={},c_bits={c[0]: 0, c[1]: 1, c[2]: 2},counts=Counter({OutcomeArray([[0]], dtype=uint8): 100}),shots=None,state=None,unitary=None,density_matrix=None)"
+      ]
+     },
+     "execution_count": 27,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "result = backend.get_result(handle)\n",
+    "\n",
+    "result"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "45cebdbb",
+   "metadata": {},
+   "source": [
+    "### Conditional Gates <a class=\"anchor\" id=\"conditional-gates\"></a>\n",
+    "\n",
+    "Pytket supports conditional gates. This may be for implementing error correction or reducing noise. This capability is well-supported by Quantinuum hardware, which supports mid-circuit measurement and qubit reuse. See [Conditional Gates](https://cqcl.github.io/pytket/manual/manual_circuit.html#classical-and-conditional-operations) for more information on pytket's implementation. The following example demonstrates the quantum teleportation protocol."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 31,
+   "id": "dc5316c0",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "\n",
+       "\n",
+       "\n",
+       "\n",
+       "\n",
+       "<iframe srcdoc=\"\n",
+       "&lt;!DOCTYPE html&gt;\n",
+       "&lt;html lang=&#34;en&#34;&gt;\n",
+       "&lt;head&gt;\n",
+       "    &lt;meta charset=&#34;UTF-8&#34;&gt;\n",
+       "    &lt;script type=&#34;application/javascript&#34; src=&#34;https://cdn.jsdelivr.net/npm/vue@3&#34;&gt;&lt;/script&gt;\n",
+       "    &lt;script type=&#34;application/javascript&#34; src=&#34;https://unpkg.com/pytket-circuit-renderer@0.3/dist/pytket-circuit-renderer.umd.js&#34;&gt;&lt;/script&gt;\n",
+       "    &lt;link rel=&#34;stylesheet&#34; href=&#34;https://unpkg.com/pytket-circuit-renderer@0.3/dist/pytket-circuit-renderer.css&#34;&gt;\n",
+       "&lt;/head&gt;\n",
+       "&lt;body&gt;\n",
+       "    &lt;div id=&#34;circuit-display-vue-container-bf6e5028-ab79-452a-96c5-9b0f364fa5d9&#34; class=&#34;pytket-circuit-display-container&#34;&gt;\n",
+       "        &lt;div style=&#34;display: none&#34;&gt;\n",
+       "            &lt;div id=&#34;circuit-json-to-display&#34;&gt;{&#34;bits&#34;: [[&#34;b&#34;, [0]], [&#34;b&#34;, [1]]], &#34;commands&#34;: [{&#34;args&#34;: [[&#34;q&#34;, [0]]], &#34;op&#34;: {&#34;type&#34;: &#34;X&#34;}}, {&#34;args&#34;: [[&#34;q&#34;, [1]]], &#34;op&#34;: {&#34;type&#34;: &#34;H&#34;}}, {&#34;args&#34;: [[&#34;q&#34;, [0]]], &#34;op&#34;: {&#34;type&#34;: &#34;H&#34;}}, {&#34;args&#34;: [[&#34;q&#34;, [1]], [&#34;q&#34;, [2]]], &#34;op&#34;: {&#34;type&#34;: &#34;CX&#34;}}, {&#34;args&#34;: [[&#34;q&#34;, [0]], [&#34;q&#34;, [1]]], &#34;op&#34;: {&#34;type&#34;: &#34;CX&#34;}}, {&#34;args&#34;: [[&#34;q&#34;, [1]], [&#34;b&#34;, [1]]], &#34;op&#34;: {&#34;type&#34;: &#34;Measure&#34;}}, {&#34;args&#34;: [[&#34;q&#34;, [0]]], &#34;op&#34;: {&#34;type&#34;: &#34;H&#34;}}, {&#34;args&#34;: [[&#34;q&#34;, [0]], [&#34;b&#34;, [0]]], &#34;op&#34;: {&#34;type&#34;: &#34;Measure&#34;}}, {&#34;args&#34;: [[&#34;b&#34;, [1]], [&#34;q&#34;, [2]]], &#34;op&#34;: {&#34;conditional&#34;: {&#34;op&#34;: {&#34;type&#34;: &#34;X&#34;}, &#34;value&#34;: 1, &#34;width&#34;: 1}, &#34;type&#34;: &#34;Conditional&#34;}}, {&#34;args&#34;: [[&#34;b&#34;, [0]], [&#34;q&#34;, [2]]], &#34;op&#34;: {&#34;conditional&#34;: {&#34;op&#34;: {&#34;type&#34;: &#34;Z&#34;}, &#34;value&#34;: 1, &#34;width&#34;: 1}, &#34;type&#34;: &#34;Conditional&#34;}}], &#34;created_qubits&#34;: [], &#34;discarded_qubits&#34;: [], &#34;implicit_permutation&#34;: [[[&#34;q&#34;, [0]], [&#34;q&#34;, [0]]], [[&#34;q&#34;, [1]], [&#34;q&#34;, [1]]], [[&#34;q&#34;, [2]], [&#34;q&#34;, [2]]]], &#34;name&#34;: &#34;Conditional Gates Example&#34;, &#34;phase&#34;: &#34;0.0&#34;, &#34;qubits&#34;: [[&#34;q&#34;, [0]], [&#34;q&#34;, [1]], [&#34;q&#34;, [2]]]}&lt;/div&gt;\n",
+       "        &lt;/div&gt;\n",
+       "        &lt;circuit-display-container :circuit-element-str=&#34;&#39;#circuit-json-to-display&#39;&#34;&gt;&lt;/circuit-display-container&gt;\n",
+       "    &lt;/div&gt;\n",
+       "    &lt;script type=&#34;application/javascript&#34;&gt;\n",
+       "        const { createApp } = Vue;\n",
+       "        const circuitDisplayContainer = window[&#34;pytket-circuit-renderer&#34;].default;\n",
+       "        // Init variables to be shared between circuit display instances\n",
+       "        if (typeof window.pytketCircuitDisplays === &#34;undefined&#34;) {\n",
+       "            window.pytketCircuitDisplays = {};\n",
+       "        }\n",
+       "        const uid = &#34;bf6e5028-ab79-452a-96c5-9b0f364fa5d9&#34;;\n",
+       "        // Create the root Vue component\n",
+       "        const app = createApp({\n",
+       "            delimiters: [&#39;[[#&#39;, &#39;#]]&#39;],\n",
+       "            components: { circuitDisplayContainer },\n",
+       "        })\n",
+       "        app.config.unwrapInjectedRef = true;\n",
+       "        app.mount(&#34;#circuit-display-vue-container-&#34;+uid);\n",
+       "        window.pytketCircuitDisplays[uid] = app;\n",
+       "    &lt;/script&gt;\n",
+       "&lt;/body&gt;\n",
+       "&lt;/html&gt;\n",
+       "\"\n",
+       "        width=\"100%\" height=\"200px\"\n",
+       "        style=\"border: none; outline: none; resize: vertical; overflow: auto\"></iframe>\n",
+       "\n"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "from pytket.circuit import Circuit, if_bit\n",
+    "\n",
+    "# create a circuit and add quantum and classical registers\n",
+    "circ = Circuit(name=\"Conditional Gates Example\")\n",
+    "qreg = circ.add_q_register(\"q\", 3)\n",
+    "creg = circ.add_c_register(\"b\", 2)\n",
+    "\n",
+    "# prepare q[0] to be in the state |->, which we wish to teleport to q[2]\n",
+    "circ.X(qreg[0]).H(qreg[0])\n",
+    "\n",
+    "# prepare a Bell state on qubits q[1] and q[2]\n",
+    "circ.H(qreg[1])\n",
+    "circ.CX(qreg[1], qreg[2])\n",
+    "\n",
+    "# construct the teleportation protocol\n",
+    "circ.CX(qreg[0], qreg[1])\n",
+    "circ.H(qreg[0])\n",
+    "circ.Measure(qreg[0], creg[0])\n",
+    "circ.Measure(qreg[1], creg[1])\n",
+    "\n",
+    "# if (creg[1] == 1)\n",
+    "circ.X(qreg[2], condition=if_bit(creg[1]))\n",
+    "\n",
+    "# if (creg[0] == 1)\n",
+    "circ.Z(qreg[2], condition=if_bit(creg[0]))\n",
+    "\n",
+    "render_circuit_jupyter(circ)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c3e661c5",
+   "metadata": {},
+   "source": [
+    "We can utilise pytket's [Assertion](https://cqcl.github.io/pytket/manual/manual_assertion.html#assertion) feature to verify the successful teleportation of the state $| - \\rangle$."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 32,
+   "id": "2815f715",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "\n",
+       "\n",
+       "\n",
+       "\n",
+       "\n",
+       "<iframe srcdoc=\"\n",
+       "&lt;!DOCTYPE html&gt;\n",
+       "&lt;html lang=&#34;en&#34;&gt;\n",
+       "&lt;head&gt;\n",
+       "    &lt;meta charset=&#34;UTF-8&#34;&gt;\n",
+       "    &lt;script type=&#34;application/javascript&#34; src=&#34;https://cdn.jsdelivr.net/npm/vue@3&#34;&gt;&lt;/script&gt;\n",
+       "    &lt;script type=&#34;application/javascript&#34; src=&#34;https://unpkg.com/pytket-circuit-renderer@0.3/dist/pytket-circuit-renderer.umd.js&#34;&gt;&lt;/script&gt;\n",
+       "    &lt;link rel=&#34;stylesheet&#34; href=&#34;https://unpkg.com/pytket-circuit-renderer@0.3/dist/pytket-circuit-renderer.css&#34;&gt;\n",
+       "&lt;/head&gt;\n",
+       "&lt;body&gt;\n",
+       "    &lt;div id=&#34;circuit-display-vue-container-ec3c25a9-10e5-4710-ac2e-e70d30e7dfc4&#34; class=&#34;pytket-circuit-display-container&#34;&gt;\n",
+       "        &lt;div style=&#34;display: none&#34;&gt;\n",
+       "            &lt;div id=&#34;circuit-json-to-display&#34;&gt;{&#34;bits&#34;: [[&#34;b&#34;, [0]], [&#34;b&#34;, [1]], [&#34;tk_DEBUG_ZERO_REG_debug&#34;, [0]]], &#34;commands&#34;: [{&#34;args&#34;: [[&#34;q&#34;, [0]]], &#34;op&#34;: {&#34;type&#34;: &#34;X&#34;}}, {&#34;args&#34;: [[&#34;q&#34;, [1]]], &#34;op&#34;: {&#34;type&#34;: &#34;H&#34;}}, {&#34;args&#34;: [[&#34;q&#34;, [0]]], &#34;op&#34;: {&#34;type&#34;: &#34;H&#34;}}, {&#34;args&#34;: [[&#34;q&#34;, [1]], [&#34;q&#34;, [2]]], &#34;op&#34;: {&#34;type&#34;: &#34;CX&#34;}}, {&#34;args&#34;: [[&#34;q&#34;, [0]], [&#34;q&#34;, [1]]], &#34;op&#34;: {&#34;type&#34;: &#34;CX&#34;}}, {&#34;args&#34;: [[&#34;q&#34;, [1]], [&#34;b&#34;, [1]]], &#34;op&#34;: {&#34;type&#34;: &#34;Measure&#34;}}, {&#34;args&#34;: [[&#34;q&#34;, [0]]], &#34;op&#34;: {&#34;type&#34;: &#34;H&#34;}}, {&#34;args&#34;: [[&#34;q&#34;, [0]], [&#34;b&#34;, [0]]], &#34;op&#34;: {&#34;type&#34;: &#34;Measure&#34;}}, {&#34;args&#34;: [[&#34;b&#34;, [1]], [&#34;q&#34;, [2]]], &#34;op&#34;: {&#34;conditional&#34;: {&#34;op&#34;: {&#34;type&#34;: &#34;X&#34;}, &#34;value&#34;: 1, &#34;width&#34;: 1}, &#34;type&#34;: &#34;Conditional&#34;}}, {&#34;args&#34;: [[&#34;b&#34;, [0]], [&#34;q&#34;, [2]]], &#34;op&#34;: {&#34;conditional&#34;: {&#34;op&#34;: {&#34;type&#34;: &#34;Z&#34;}, &#34;value&#34;: 1, &#34;width&#34;: 1}, &#34;type&#34;: &#34;Conditional&#34;}}, {&#34;args&#34;: [[&#34;q&#34;, [2]], [&#34;tk_DEBUG_ZERO_REG_debug&#34;, [0]]], &#34;op&#34;: {&#34;box&#34;: {&#34;id&#34;: &#34;29361803-fa0e-4ef5-b255-1d040657a980&#34;, &#34;matrix&#34;: [[[0.5, 0.0], [-0.5, 0.0]], [[-0.5, 0.0], [0.5, 0.0]]], &#34;type&#34;: &#34;ProjectorAssertionBox&#34;}, &#34;type&#34;: &#34;ProjectorAssertionBox&#34;}}], &#34;created_qubits&#34;: [], &#34;discarded_qubits&#34;: [], &#34;implicit_permutation&#34;: [[[&#34;q&#34;, [0]], [&#34;q&#34;, [0]]], [[&#34;q&#34;, [1]], [&#34;q&#34;, [1]]], [[&#34;q&#34;, [2]], [&#34;q&#34;, [2]]]], &#34;name&#34;: &#34;Conditional Gates Example&#34;, &#34;phase&#34;: &#34;0.0&#34;, &#34;qubits&#34;: [[&#34;q&#34;, [0]], [&#34;q&#34;, [1]], [&#34;q&#34;, [2]]]}&lt;/div&gt;\n",
+       "        &lt;/div&gt;\n",
+       "        &lt;circuit-display-container :circuit-element-str=&#34;&#39;#circuit-json-to-display&#39;&#34;&gt;&lt;/circuit-display-container&gt;\n",
+       "    &lt;/div&gt;\n",
+       "    &lt;script type=&#34;application/javascript&#34;&gt;\n",
+       "        const { createApp } = Vue;\n",
+       "        const circuitDisplayContainer = window[&#34;pytket-circuit-renderer&#34;].default;\n",
+       "        // Init variables to be shared between circuit display instances\n",
+       "        if (typeof window.pytketCircuitDisplays === &#34;undefined&#34;) {\n",
+       "            window.pytketCircuitDisplays = {};\n",
+       "        }\n",
+       "        const uid = &#34;ec3c25a9-10e5-4710-ac2e-e70d30e7dfc4&#34;;\n",
+       "        // Create the root Vue component\n",
+       "        const app = createApp({\n",
+       "            delimiters: [&#39;[[#&#39;, &#39;#]]&#39;],\n",
+       "            components: { circuitDisplayContainer },\n",
+       "        })\n",
+       "        app.config.unwrapInjectedRef = true;\n",
+       "        app.mount(&#34;#circuit-display-vue-container-&#34;+uid);\n",
+       "        window.pytketCircuitDisplays[uid] = app;\n",
+       "    &lt;/script&gt;\n",
+       "&lt;/body&gt;\n",
+       "&lt;/html&gt;\n",
+       "\"\n",
+       "        width=\"100%\" height=\"200px\"\n",
+       "        style=\"border: none; outline: none; resize: vertical; overflow: auto\"></iframe>\n",
+       "\n"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "from pytket.circuit import ProjectorAssertionBox\n",
+    "import numpy as np\n",
+    "\n",
+    "# |-><-|\n",
+    "proj = np.array([\n",
+    "    [0.5, -0.5],\n",
+    "    [-0.5, 0.5]\n",
+    "])\n",
+    "circ.add_assertion(ProjectorAssertionBox(proj), [qreg[2]], name=\"debug\")\n",
+    "\n",
+    "render_circuit_jupyter(circ)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 35,
+   "id": "ac5c88ee",
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [
+    {
+     "ename": "CircuitNotValidError",
+     "evalue": "Circuit with index 0 in submitted does not satisfy NoMidMeasurePredicate (try compiling with backend.get_compiled_circuits first).",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[1;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[1;31mCircuitNotValidError\u001b[0m                      Traceback (most recent call last)",
+      "Input \u001b[1;32mIn [35]\u001b[0m, in \u001b[0;36m<cell line: 3>\u001b[1;34m()\u001b[0m\n\u001b[0;32m      1\u001b[0m n_shots \u001b[38;5;241m=\u001b[39m \u001b[38;5;241m100\u001b[39m\n\u001b[0;32m      2\u001b[0m compiled_circuit \u001b[38;5;241m=\u001b[39m backend\u001b[38;5;241m.\u001b[39mget_compiled_circuit(circ)\n\u001b[1;32m----> 3\u001b[0m handle \u001b[38;5;241m=\u001b[39m \u001b[43mbackend\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mprocess_circuit\u001b[49m\u001b[43m(\u001b[49m\u001b[43mcompiled_circuit\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\n\u001b[0;32m      4\u001b[0m \u001b[43m                                 \u001b[49m\u001b[43mn_shots\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mn_shots\u001b[49m\u001b[43m)\u001b[49m\n",
+      "File \u001b[1;32m~\\Envs\\azure-quantum\\lib\\site-packages\\pytket\\backends\\backend.py:256\u001b[0m, in \u001b[0;36mBackend.process_circuit\u001b[1;34m(self, circuit, n_shots, valid_check, **kwargs)\u001b[0m\n\u001b[0;32m    244\u001b[0m \u001b[38;5;28;01mdef\u001b[39;00m \u001b[38;5;21mprocess_circuit\u001b[39m(\n\u001b[0;32m    245\u001b[0m     \u001b[38;5;28mself\u001b[39m,\n\u001b[0;32m    246\u001b[0m     circuit: Circuit,\n\u001b[1;32m   (...)\u001b[0m\n\u001b[0;32m    249\u001b[0m     \u001b[38;5;241m*\u001b[39m\u001b[38;5;241m*\u001b[39mkwargs: KwargTypes,\n\u001b[0;32m    250\u001b[0m ) \u001b[38;5;241m-\u001b[39m\u001b[38;5;241m>\u001b[39m ResultHandle:\n\u001b[0;32m    251\u001b[0m     \u001b[38;5;124;03m\"\"\"\u001b[39;00m\n\u001b[0;32m    252\u001b[0m \u001b[38;5;124;03m    Submit a single circuit to the backend for running. See\u001b[39;00m\n\u001b[0;32m    253\u001b[0m \u001b[38;5;124;03m    :py:meth:`Backend.process_circuits`.\u001b[39;00m\n\u001b[0;32m    254\u001b[0m \u001b[38;5;124;03m    \"\"\"\u001b[39;00m\n\u001b[1;32m--> 256\u001b[0m     \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mprocess_circuits(\n\u001b[0;32m    257\u001b[0m         [circuit], n_shots\u001b[38;5;241m=\u001b[39mn_shots, valid_check\u001b[38;5;241m=\u001b[39mvalid_check, \u001b[38;5;241m*\u001b[39m\u001b[38;5;241m*\u001b[39mkwargs\n\u001b[0;32m    258\u001b[0m     )[\u001b[38;5;241m0\u001b[39m]\n",
+      "File \u001b[1;32m~\\Envs\\azure-quantum\\lib\\site-packages\\pytket\\extensions\\qsharp\\backends\\azure_quantum.py:191\u001b[0m, in \u001b[0;36mAzureBackend.process_circuits\u001b[1;34m(self, circuits, n_shots, valid_check, **kwargs)\u001b[0m\n\u001b[0;32m    184\u001b[0m n_shots_list \u001b[38;5;241m=\u001b[39m Backend\u001b[38;5;241m.\u001b[39m_get_n_shots_as_list(\n\u001b[0;32m    185\u001b[0m     n_shots,\n\u001b[0;32m    186\u001b[0m     \u001b[38;5;28mlen\u001b[39m(circuits),\n\u001b[0;32m    187\u001b[0m     optional\u001b[38;5;241m=\u001b[39m\u001b[38;5;28;01mFalse\u001b[39;00m,\n\u001b[0;32m    188\u001b[0m )\n\u001b[0;32m    190\u001b[0m \u001b[38;5;28;01mif\u001b[39;00m valid_check:\n\u001b[1;32m--> 191\u001b[0m     \u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43m_check_all_circuits\u001b[49m\u001b[43m(\u001b[49m\u001b[43mcircuits\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mnomeasure_warn\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[38;5;28;43;01mTrue\u001b[39;49;00m\u001b[43m)\u001b[49m\n\u001b[0;32m    193\u001b[0m postprocess \u001b[38;5;241m=\u001b[39m kwargs\u001b[38;5;241m.\u001b[39mget(\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mpostprocess\u001b[39m\u001b[38;5;124m\"\u001b[39m, \u001b[38;5;28;01mFalse\u001b[39;00m)\n\u001b[0;32m    195\u001b[0m handles \u001b[38;5;241m=\u001b[39m []\n",
+      "File \u001b[1;32m~\\Envs\\azure-quantum\\lib\\site-packages\\pytket\\backends\\backend.py:125\u001b[0m, in \u001b[0;36mBackend._check_all_circuits\u001b[1;34m(self, circuits, nomeasure_warn)\u001b[0m\n\u001b[0;32m    119\u001b[0m errors \u001b[38;5;241m=\u001b[39m (\n\u001b[0;32m    120\u001b[0m     CircuitNotValidError(i, \u001b[38;5;28mrepr\u001b[39m(pred))\n\u001b[0;32m    121\u001b[0m     \u001b[38;5;28;01mfor\u001b[39;00m pred \u001b[38;5;129;01min\u001b[39;00m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mrequired_predicates\n\u001b[0;32m    122\u001b[0m     \u001b[38;5;28;01mif\u001b[39;00m \u001b[38;5;129;01mnot\u001b[39;00m pred\u001b[38;5;241m.\u001b[39mverify(circ)\n\u001b[0;32m    123\u001b[0m )\n\u001b[0;32m    124\u001b[0m \u001b[38;5;28;01mfor\u001b[39;00m error \u001b[38;5;129;01min\u001b[39;00m errors:\n\u001b[1;32m--> 125\u001b[0m     \u001b[38;5;28;01mraise\u001b[39;00m error\n\u001b[0;32m    126\u001b[0m \u001b[38;5;28;01mif\u001b[39;00m nomeasure_warn:\n\u001b[0;32m    127\u001b[0m     \u001b[38;5;28;01mif\u001b[39;00m circ\u001b[38;5;241m.\u001b[39mn_gates_of_type(OpType\u001b[38;5;241m.\u001b[39mMeasure) \u001b[38;5;241m<\u001b[39m \u001b[38;5;241m1\u001b[39m:\n",
+      "\u001b[1;31mCircuitNotValidError\u001b[0m: Circuit with index 0 in submitted does not satisfy NoMidMeasurePredicate (try compiling with backend.get_compiled_circuits first)."
+     ]
+    }
+   ],
+   "source": [
+    "n_shots = 100\n",
+    "compiled_circuit = backend.get_compiled_circuit(circ)\n",
+    "handle = backend.process_circuit(compiled_circuit, \n",
+    "                                 n_shots=n_shots)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a74af119",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "status = backend.circuit_status(handle)\n",
+    "status"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "35e77d07",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "result = backend.get_result(handle)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "dcab62b1",
+   "metadata": {},
+   "source": [
+    "The `get_debug_info` function returns the success rate of the state assertion averaged across shots. Note that the failed shots are caused by the simulated device errors"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "43c72494",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "result.get_debug_info()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d300f995",
+   "metadata": {},
+   "source": [
+    "<div align=\"center\"> &copy; 2023 by Quantinuum. All Rights Reserved. </div>"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.10"
+  },
+  "vscode": {
+   "interpreter": {
+    "hash": "c91c3faa82aad5b8fd8e5c246f2148b117d9b10fafcbd8b7de05f9480e768361"
+   }
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/examples/Using the Quantinuum Emulators via Azure Quantum and pytket-qsharp.ipynb
+++ b/examples/Using the Quantinuum Emulators via Azure Quantum and pytket-qsharp.ipynb
@@ -1,0 +1,1039 @@
+{
+ "cells": [
+  {
+   "attachments": {
+    "Quantinuum%20Logos_primary_blue_small.svg": {
+     "image/svg+xml": [
+      "PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiIHN0YW5kYWxvbmU9Im5vIj8+CjwhLS0gQ3JlYXRlZCB3aXRoIElua3NjYXBlIChodHRwOi8vd3d3Lmlua3NjYXBlLm9yZy8pIC0tPgoKPHN2ZwogICB2ZXJzaW9uPSIxLjEiCiAgIGlkPSJzdmc5IgogICB3aWR0aD0iMTMwLjA5ODYyIgogICBoZWlnaHQ9Ijc1LjAwMDA2OSIKICAgdmlld0JveD0iMCAwIDEzMC4wOTg2MSA3NS4wMDAwNzQiCiAgIHNvZGlwb2RpOmRvY25hbWU9IlF1YW50aW51dW0gTG9nb3NfcHJpbWFyeV9ibHVlLnN2ZyIKICAgaW5rc2NhcGU6dmVyc2lvbj0iMS4xLjIgKGI4ZTI1YmU4MzMsIDIwMjItMDItMDUpIgogICB4bWxuczppbmtzY2FwZT0iaHR0cDovL3d3dy5pbmtzY2FwZS5vcmcvbmFtZXNwYWNlcy9pbmtzY2FwZSIKICAgeG1sbnM6c29kaXBvZGk9Imh0dHA6Ly9zb2RpcG9kaS5zb3VyY2Vmb3JnZS5uZXQvRFREL3NvZGlwb2RpLTAuZHRkIgogICB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciCiAgIHhtbG5zOnN2Zz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciPgogIDxkZWZzCiAgICAgaWQ9ImRlZnMxMyIgLz4KICA8c29kaXBvZGk6bmFtZWR2aWV3CiAgICAgaWQ9Im5hbWVkdmlldzExIgogICAgIHBhZ2Vjb2xvcj0iI2ZmZmZmZiIKICAgICBib3JkZXJjb2xvcj0iIzY2NjY2NiIKICAgICBib3JkZXJvcGFjaXR5PSIxLjAiCiAgICAgaW5rc2NhcGU6cGFnZXNoYWRvdz0iMiIKICAgICBpbmtzY2FwZTpwYWdlb3BhY2l0eT0iMC4wIgogICAgIGlua3NjYXBlOnBhZ2VjaGVja2VyYm9hcmQ9IjAiCiAgICAgc2hvd2dyaWQ9ImZhbHNlIgogICAgIGZpdC1tYXJnaW4tbGVmdD0iMCIKICAgICBmaXQtbWFyZ2luLWJvdHRvbT0iMCIKICAgICBmaXQtbWFyZ2luLXJpZ2h0PSIwIgogICAgIGZpdC1tYXJnaW4tdG9wPSIwIgogICAgIGlua3NjYXBlOnpvb209IjEuNjQ2NTQ3NCIKICAgICBpbmtzY2FwZTpjeD0iLTI5LjQ1NTU3NSIKICAgICBpbmtzY2FwZTpjeT0iMTM1LjczODU4IgogICAgIGlua3NjYXBlOndpbmRvdy13aWR0aD0iMTkyMCIKICAgICBpbmtzY2FwZTp3aW5kb3ctaGVpZ2h0PSIxMjAxIgogICAgIGlua3NjYXBlOndpbmRvdy14PSItOSIKICAgICBpbmtzY2FwZTp3aW5kb3cteT0iLTkiCiAgICAgaW5rc2NhcGU6d2luZG93LW1heGltaXplZD0iMSIKICAgICBpbmtzY2FwZTpjdXJyZW50LWxheWVyPSJnMTUiCiAgICAgd2lkdGg9IjM0NS42MTQxNHB4IgogICAgIHVuaXRzPSJtbSIKICAgICBzY2FsZS14PSIxIiAvPgogIDxnCiAgICAgaW5rc2NhcGU6Z3JvdXBtb2RlPSJsYXllciIKICAgICBpbmtzY2FwZTpsYWJlbD0iSW1hZ2UiCiAgICAgaWQ9ImcxNSIKICAgICB0cmFuc2Zvcm09InRyYW5zbGF0ZSgtMzIuOTUwNzIsLTMxLjgwMzE4MikiPgogICAgPHBhdGgKICAgICAgIHN0eWxlPSJmaWxsOiM3NDgwOTk7ZmlsbC1vcGFjaXR5OjE7c3Ryb2tlLXdpZHRoOjAuMTI0MDQ2IgogICAgICAgZD0ibSAzNy41NTAzNDEsMTA2LjcxMjE1IGMgLTEuNDAzNTg4LC0wLjI3ODMgLTMuMTE0OTU0LC0xLjQ4MzE1IC0zLjgyMzE1OSwtMi42OTE2IC0xLjA2NzMzNCwtMS44MjEyNyAtMS4wMzAzMzQsLTQuNDQwNzc5IDAuMDg2NTUsLTYuMTI2OTYxIDEuODA2ODQ2LC0yLjcyNzgzNiA1LjQxMDAwNSwtMy40NTIxMDUgOC4xNDQ0MjQsLTEuNjM3MDk1IDEuMjI5MjY0LDAuODE1OTM0IDIuMDk2NjU1LDIuMTY3NjAxIDIuNDA4NjQ3LDMuNzUzNDE2IDAuMTU3OTY0LDAuODAyOTMgMC4xMDAwNTEsMi4wNzEwNSAtMC4xMjExNTgsMi42NTI4NyAtMC4xMjEzNjgsMC4zMTkyMiAtMC4xNzEwNzIsMC4zMzcwOSAtMC45Mzc1MzIsMC4zMzcwOSAtMC40NDUxNTEsMCAtMC44MDkzNjksLTAuMDMxNCAtMC44MDkzNjksLTAuMDY5NyAwLC0wLjAzODMgMC4wOTA5MiwtMC4zNDc3MSAwLjIwMjA0OCwtMC42ODc0NiAwLjI5MjI0OCwtMC44OTM0OSAwLjE4NTMxNywtMi4yMDg1MyAtMC4yNDg5MzgsLTMuMDYxNDY5IC0wLjQ0MjQyMSwtMC44Njg5ODkgLTEuMTg0OTAyLC0xLjU5MTU3NyAtMi4wNDM1MzYsLTEuOTg4ODA4IC0xLjAwNjAxNywtMC40NjU0MTMgLTIuMzk3MzU1LC0wLjQ2Nzg1MSAtMy4zODI0ODEsLTAuMDA2IC0wLjk3OTM5NywwLjQ1OTIyNiAtMS42NTMxODgsMS4xMTU5ODcgLTIuMTIyMDc0LDIuMDY4NDI4IC0wLjM1MDkyMiwwLjcxMjgyMyAtMC40MDE1NDUsMC45Mzg0NTkgLTAuMzkzNTk4LDEuNzU0MzA5IDAuMDE3MDksMS43NTM3MyAwLjg2NTc3OSwzLjExOTU2IDIuMzc5MTc4LDMuODI4ODggMC43MDMxMzUsMC4zMjk1NiAwLjc0MDYwMSwwLjMzMzE1IDQuMTIwODUsMC4zOTQ2IGwgMy40MTEyNjMsMC4wNjIgdiAwLjc0NDI3IDAuNzQ0MjggbCAtMy4xNjMxNzEsMC4wMTg1IGMgLTEuNzM5NzQ1LDAuMDEwMSAtMy40MDgzMTksLTAuMDMwMiAtMy43MDc5MzksLTAuMDg5NiB6IG0gMTQuMDA5Mzc0LC0yLjIzNTE5IGMgLTEuMjM1NDUxLC0wLjI0MjE3IC0yLjUxODUwOSwtMS4xNjQ5NyAtMy4xNzQ4MjksLTIuMjgzMzkgLTAuNTQwMTA4LC0wLjkyMDM4IC0wLjY3NjIxNywtMS43ODQzNCAtMC42NzYyMTcsLTQuMjkyMzc2IDAsLTIuNTU0MjA0IC0wLjAyODEsLTIuNDY4MTI2IDAuODA2Mjk5LC0yLjQ2ODEyNiAwLjgzNjgwMiwwIDAuODA2MDIzLC0wLjA5ODQ1IDAuODA5MDI0LDIuNTg3MjI2IDAuMDAzMSwyLjcxNDMzNiAwLjA5NjE1LDMuMTIzMTI2IDAuOTAzNjI4LDMuOTY3MDY2IDAuNjcyMDAzLDAuNzAyMzUgMS4yNjQxODcsMC45NDQzNSAyLjMxODg0MSwwLjk0NzYxIDAuNzkyOTg0LDAuMDAyIDEuMDE1NDEsLTAuMDQ3MSAxLjUwNjQ4OSwtMC4zMzU4MSAwLjMxNjg4MiwtMC4xODYyOSAwLjczMDA0MSwtMC41MjEyMSAwLjkxODEzMywtMC43NDQyOCAwLjY3NTUwNCwtMC44MDExMiAwLjczMzc5OCwtMS4wNzkwNCAwLjgwMDU3MywtMy44MTY4NDggbCAwLjA2MjAzLC0yLjU0Mjk0NiAwLjU5ODg1NCwtMC4wMzgxNyBjIDAuOTQ0MDIxLC0wLjA2MDIzIDAuOTUxNzIsLTAuMDQxNCAwLjk1MTcyLDIuMzI1NDYgMCwxLjEzODk1MiAtMC4wNjA2OCwyLjQwMjA0NCAtMC4xMzQ4MzEsMi44MDY4NjQgLTAuMzU5MDUxLDEuOTYwMDQgLTEuOTE3MDM3LDMuNTM1NTYgLTMuODYwNzU1LDMuOTA0MTcgLTAuNzIzNzI3LDAuMTM3MjUgLTEuMDYwNDc3LDAuMTM0MjMgLTEuODI4OTUzLC0wLjAxNjQgeiBtIDc0LjczMjA2NSwtMC4wMzY1IGMgLTEuNDMxMzgsLTAuMzQ4MDkgLTIuNjQ4MDUsLTEuMzM4MzggLTMuMjY3MzEsLTIuNjU5NCAtMC4zMjY2OSwtMC42OTY4NyAtMC4zMzAwMiwtMC43MzIxNCAtMC4zMzAwMiwtMy40OTUwMTUgdiAtMi43OTEwMzIgaCAwLjY4MjI1IDAuNjgyMjYgbCAwLjA2NTMsMi41NDI5MzkgYyAwLjA2MywyLjQ1NzM2OCAwLjA3NjQsMi41NjQ0MzggMC4zOTg4OCwzLjE4MTYyOCAwLjgwNjAyLDEuNTQyODYgMi42MTMwMywyLjE5MzMyIDQuMTMwMzQsMS40ODY3NyAwLjczNzQ0LC0wLjM0MzQgMS42MTQyMiwtMS4yODQ5NiAxLjc5MTc3LC0xLjkyNDE3IDAuMDY4NiwtMC4yNDcxNiAwLjEyNTE0LC0xLjQ4OTE3NyAwLjEyNTUxLC0yLjc2MDA0NiA3LjVlLTQsLTIuNjMyODExIC0wLjAwMSwtMi42MjYxODEgMC45NTI0MSwtMi41NjUzMjYgbCAwLjU5ODg2LDAuMDM4MTggdiAyLjcyOTAxNCAyLjcyOTAwOCBsIC0wLjM5Mzc3LDAuODMxMiBjIC0wLjY2MzMyLDEuNDAwMTggLTEuNjkyNDgsMi4yNDMyOSAtMy4yMjU4NCwyLjY0MjY3IC0wLjgzNDU4LDAuMjE3MzkgLTEuMzU5MTQsMC4yMjA2MSAtMi4yMTA1NSwwLjAxMzYgeiBtIDEzLjM5Njk3LDAgYyAtMS40MzEzOCwtMC4zNDgwOSAtMi42NDgwNiwtMS4zMzgzOCAtMy4yNjczMiwtMi42NTk0IC0wLjMyNjY5LC0wLjY5Njg3IC0wLjMzMDAyLC0wLjczMjE0IC0wLjMzMDAyLC0zLjQ5NTAxNSB2IC0yLjc5MTAzMiBoIDAuNjgyMjUgMC42ODIyNiBsIDAuMDY1MywyLjU0MjkzOSBjIDAuMDYzLDIuNDU3MzY4IDAuMDc2NCwyLjU2NDQzOCAwLjM5ODg3LDMuMTgxNjI4IDEuMDU0NzUsMi4wMTg5OCAzLjYxODI5LDIuMzY4NDggNS4yMDQ5NiwwLjcwOTY0IDAuNzc5NDUsLTAuODE0OTEgMC44NDMzNiwtMS4xMDM2NSAwLjg0MzM2LC0zLjgxMDA2NiAwLC0yLjc0MDU3OSAtMC4wMDYsLTIuNzIzNDQxIDAuOTUxNzIsLTIuNjYyMzQ2IGwgMC41OTg4NSwwLjAzODE4IHYgMi43MjkwMTQgYyAwLDIuNzI0Mjg4IDAsMi43MzAyODggLTAuMzQ0NDgsMy40NjQ2MTggLTAuNjc4ODQsMS40NDk1MyAtMS43Mzk4OCwyLjM0MjE5IC0zLjI0NzksMi43MzI0MyAtMC44NjIyMSwwLjIyMzExIC0xLjM4MTUxLDAuMjI3NjEgLTIuMjM3NzcsMC4wMTk0IHogbSAtODAuMDcxNjY5LC0wLjI0NzY5IGMgMCwtMC4xNzkzMSA0LjEyNzg0NiwtOC4zMTYxMjYgNC4zNjE4MzksLTguNTk4MDc0IDAuMTQ1ODYzLC0wLjE3NTc0OCAxLjkxNTUyNSwtMC4yMzAyODggMi4xNjYyNjUsLTAuMDY2NzUgMC4xMzMzODUsMC4wODY5OSA0LjUxMTk4Niw4LjU4MTkxNCA0LjUxMTk4Niw4Ljc1MzY5NCAwLDAuMDQ1NSAtMC4zNjU0MjgsMC4wODI3IC0wLjgxMjA2NywwLjA4MjcgLTAuNzc5ODcsMCAtMC44MjA0NDQsLTAuMDE1MiAtMS4wMjMzNzksLTAuMzg0MzYgLTAuMTE2MjIsLTAuMjExMzkgLTAuMzEzNzk0LC0wLjUxOTM1IC0wLjQzOTA1MywtMC42ODQzNSBsIC0wLjIyNzc0MSwtMC4zMDAwMSAtMy4xMjE1LDAuMDMzMSAtMy4xMjE1LDAuMDMzMSAtMC4zNDksMC42NTEyNCAtMC4zNDg5OTksMC42NTEyNCBoIC0wLjc5ODQyNiBjIC0wLjU5Njk3NCwwIC0wLjc5ODQyNSwtMC4wNDMzIC0wLjc5ODQyNSwtMC4xNzE1NCB6IG0gNy41NjY4MDMsLTIuODA0MTcgYyAwLjE1NTk4LC0wLjA5OTYgMC4wMTU1NSwtMC40NTU0IC0wLjg2ODMyMSwtMi4xOTk5MjIgLTAuNTc5OTE1LC0xLjE0NDU3NiAtMS4xMjY3NTIsLTIuMDgxMDUgLTEuMjE1MTk4LC0yLjA4MTA1IC0wLjA4ODQ0LDAgLTAuNjQ2NDM0LDAuOTM3MTY0IC0xLjIzOTk3OSwyLjA4MjU4OCAtMC45MDA4NDUsMS43Mzg0NjQgLTEuMDQ4NTAyLDIuMTAxOTg0IC0wLjg5MzU4LDIuMTk5OTE0IDAuMjQzMzI4LDAuMTUzODMgMy45NzYwMDMsMC4xNTI0NiA0LjIxNzA3OCwtMC4wMDIgeiBtIDYuOTc2MDE5LC0xLjQ1ODkyOCAwLjAzMjU3LC00LjQzNDY0NCAwLjgzODA3NCwtMC4wMzY2OCAwLjgzODA3LC0wLjAzNjY4IDMuNTAwNTU4LDMuNDA2OTQgYyAxLjkyNTMwNSwxLjg3MzgyMiAzLjU0Mzc2LDMuMzgwMjQyIDMuNTk2NTczLDMuMzQ3NjAyIDAuMDUyODEsLTAuMDMyNiAwLjA5NjAxLC0xLjUwMDU0IDAuMDk2MDEsLTMuMjYyMDIgMCwtMy42MjM5NTIgLTAuMDI4NjUsLTMuNTE5ODc1IDAuOTUxNzE1LC0zLjQ1NzMzMiBsIDAuNTk4ODUzLDAuMDM4MTcgMC4wMzI2Miw0LjQzNDY0NCAwLjAzMjU1LDQuNDM0NjM4IC0xLjA4Njk2OSwwLjAwMiAtMS4wODY5NywwLjAwMSAtMy4yOTE3NTMsLTMuMzczODcgYyAtMi4xNDA3OTIsLTIuMTk0MjgyIC0zLjM0NDM4NywtMy4zNDE0MzEgLTMuNDQyMjc1LC0zLjI4MDkzNiAtMC4xMTE4NTUsMC4wNjkxNSAtMC4xNTA1MjIsMC45MzU1NTkgLTAuMTUwNTIyLDMuMzcyOTI2IHYgMy4yNzk4OSBoIC0wLjc0NTg0MiAtMC43NDU4NDIgeiBtIDE4LjE0MjIzMiw0LjI4NTgxOCBjIC0wLjAzMzA4LC0wLjA4ODcgLTAuMDc0MjUsLTEuNzI0MjcgLTAuMDkxNTQsLTMuNjM0NTggbCAtMC4wMzE0MywtMy40NzMyODIgLTIuMDgzNjA4LC0wLjAzNDA1IC0yLjA4MzYwNywtMC4wMzQwNSAwLjAzNjksLTAuNzcyMjYxIDAuMDM2ODMsLTAuNzcyMjY5IGggNC45NjE4NDIgNC45NjE4MzQgbCAwLjAzNjksMC43NzIyNjkgMC4wMzY4MywwLjc3MjI2MSAtMi4wODM2MDgsMC4wMzQwNSAtMi4wODM2MTUsMC4wMzQwNSAtMC4wNjIwMiwzLjU5NzMzMiAtMC4wNjIwMywzLjU5NzMzIC0wLjcxNDc2NiwwLjAzNzMgYyAtMC41MDA5MTksMC4wMjYxIC0wLjczMjc0NCwtMC4wMTEgLTAuNzc0ODQ5LC0wLjEyNDA1IHogbSA5LjY0NDA2NSwtNC4yODU4MTggMC4wMzI2LC00LjQzNDY0NCBoIDAuNjgyMjUgMC42ODIyNSBsIDAuMDMyNiw0LjQzNDY0NCAwLjAzMjYsNC40MzQ2NDggaCAtMC43NDc0MSAtMC43NDc0MSB6IG0gNi4yMDIyOSwwIDAuMDMyNiwtNC40MzQ2NDQgMC44Mzk1MywtMC4wMzY3NSAwLjgzOTUyLC0wLjAzNjc1IDMuNTAyMDksMy40MDQ5ODIgYyAxLjkyNjE0LDEuODcyNzUgMy41NDM5NCwzLjM3OTE4IDMuNTk1MTEsMy4zNDc2NCAwLjA1MTEsLTAuMDMxNiAwLjA5MywtMS40OTg1NSAwLjA5MywtMy4yNjAwMjUgMCwtMy42MjM5NiAtMC4wMjg2LC0zLjUxOTg3NSAwLjk1MTczLC0zLjQ1NzMzOSBsIDAuNTk4ODUsMC4wMzgxOCAwLjAzMjYsNC40MzQ2NDMgMC4wMzI2LDQuNDM0NjQxIGggLTEuMDc2NTUgLTEuMDc2NTYgbCAtMy4zMDM0NCwtMy4zNzIxMyBjIC0yLjEyODI2LC0yLjE3MjUxMiAtMy4zNTY1NCwtMy4zMzkzMjYgLTMuNDUyNywtMy4yNzk5MDQgLTAuMTEwMiwwLjA2ODEgLTAuMTQ5MjQsMC45NTAxMzkgLTAuMTQ5MjQsMy4zNzIxMzQgdiAzLjI3OTkgaCAtMC43NDU4NSAtMC43NDU4NCB6IG0gNDEuMzA3MzEsMCAwLjAzMjUsLTQuNDM0NjQ0IDEuMTE2NDEsLTAuMDMxNTggYyAwLjYxNDAzLC0wLjAxNzQgMS4xODM2NiwwLjAxMjIzIDEuMjY1ODUsMC4wNjU4NSAwLjA4MjIsMC4wNTM1NSAxLjA2NDIyLDEuNzQyNDE4IDIuMTgyMywzLjc1Mjk1MyAxLjExODA5LDIuMDEwNTE5IDIuMTAzMjIsMy42NTU1MDkgMi4xODkyMSwzLjY1NTUwOSAwLjA4NiwwIDEuMDQwMTUsLTEuNjA4ODEgMi4xMjAzOSwtMy41NzUxMDkgMS4wODAyNCwtMS45NjYzMTUgMi4wMzAyOCwtMy42NTQ4OSAyLjExMTIsLTMuNzUyMzkgMC4yMDM3NiwtMC4yNDU1MjEgMi4yNTczNSwtMC4yNTE3OTggMi40NjAwOCwtMC4wMDc1IDAuMTAwNTYsMC4xMjExNjIgMC4xMzE1NCwxLjM5MDM4MiAwLjEwODIzLDQuNDM0NjM5IGwgLTAuMDMyNyw0LjI2NDkgLTAuNzc1MjksMC4wMzcgLTAuNzc1MjgsMC4wMzcgdiAtMy4zNDc4NCBjIDAsLTEuODQxMzEyIC0wLjA0OTUsLTMuMzc4NDMxIC0wLjExLC0zLjQxNTgxOSAtMC4xNjE4NSwtMC4xMDAwMzUgLTAuMjE3NTMsLTAuMDA5OSAtMS44NzI2OSwzLjAzMDQzOSAtMC44MzU2OSwxLjUzNTA3IC0xLjY1MzI5LDMuMDAwMzYgLTEuODE2ODksMy4yNTYyMSBsIC0wLjI5NzQ2LDAuNDY1MTYgaCAtMS4xNTMzNyAtMS4xNTMzOCBsIC0xLjg5MzgzLC0zLjQxMTI2IGMgLTEuMDQxNjIsLTEuODc2MTg3IC0xLjkzOTI2LC0zLjQxMTI1OSAtMS45OTQ3NywtMy40MTEyNTkgLTAuMjE2NDYsMCAtMC4yNTE1MiwwLjUwMjgwMSAtMC4yNTE1MiwzLjYwNzQ3OSB2IDMuMjE1MDQgSCAxNTAuMTY5IDE0OS40MjMxNSBaIE0gOTQuMDMzNDY3LDc3LjE5NDg4IGMgLTAuNjE3NTI4LC0wLjA1MTAxIC0xLjc1MjU3MiwtMC4yMTMyMzkgLTIuNTIyMzI4LC0wLjM2MDUwOCAtNS43OTI2NDEsLTEuMTA4MjUgLTExLjMwMTM3MSwtNC43NjYwMjggLTE0LjU5NzgxMSwtOS42OTI4OTQgLTUuMjI3MjgyLC03LjgxMjcgLTQuNzk3MDU5LC0xOS4yMDM0OSAxLjAwNDYxNywtMjYuNTk4NzQ5IDAuNzI1NTUzLC0wLjkyNDg0NCAyLjA0MjY3MiwtMi4zMTI3NjkgMi4wNDI2NzIsLTIuMTUyNDc4IDAsMC4wMzkwNiAtMC4yMTYyNzQsMC41MzkzNTIgLTAuNDgwNjEyLDEuMTExNzUxIC0wLjYyNDg3MywxLjM1MzExNSAtMS4xODYzNDQsMy4xMjA1MTkgLTEuNDU2MzQ5LDQuNTg0Mjk0IC0wLjI4OTY5LDEuNTcwNTE3IC0wLjI5NTUwMSw0LjcxODM5IC0wLjAxMTU1LDYuMjcyODk1IDEuMzUwNDg4LDcuMzk0MDI4IDYuOTI3ODkxLDEzLjA2NTczMSAxNC40NzI3NzQsMTQuNzE3NDczIDEuMTQ3NTMyLDAuMjUxMjIgMS41NTU5ODIsMC4yNjAyNzEgMTMuNjgxNjcsMC4zMDMxMjkgbCAxMi40OTg4MywwLjA0NDE3IC0wLjAzMjMsNS45MTgxODMgLTAuMDMyMiw1LjkxODE4MiAtMTEuNzIyMzQsMC4wMTM2NCBjIC02LjQ0NzI5LDAuMDA3NSAtMTIuMjI3NTkyLC0wLjAyODEgLTEyLjg0NTEyLC0wLjA3OTEgeiBNIDExNC4xNDMyOCw2Mi41MzM4MzQgYyAtMC4wMjcxLC0wLjA4NzQ2IC0wLjA4MTEsLTAuODg0Njg0IC0wLjExOTk2LC0xLjc3MTYxMyAtMC4xNzM3NCwtMy45NjI5ODIgLTEuNTk4MzYsLTcuNTYyOTk5IC00LjE5Nzg1LC0xMC42MDc5NjMgLTIuNjQwNjQsLTMuMDkzMTUyIC02LjU5MDM2LC01LjMyMzg3MSAtMTAuODg1ODE4LC02LjE0ODA3MyAtMS43NTI5MzMsLTAuMzM2MzQ5IC01LjA4Mzg2NywtMC4zMTA4ODggLTYuNzgzODgsMC4wNTE4NSAtNC4wMjg5NTMsMC44NTk2ODggLTcuNTM1MDM1LDIuOTYzMTcxIC0xMC4wNjQ3OTMsNi4wMzgzOTggLTAuNTIzNTU5LDAuNjM2NDQ4IC0wLjk5OTU5LDEuMTExMDE1IC0xLjA1Nzg0OSwxLjA1NDU5NSAtMC40MDAxMTMsLTAuMzg3NDkyIC0wLjY4OTQ4NiwtMy45MjU0OTcgLTAuNDYxODE5LC01LjY0NjQ2OCAwLjcyNDQ0NCwtNS40NzYyNzIgMy43OTU3MzgsLTkuODA1ODk4IDguNjMwNzMyLC0xMi4xNjY3OTggMy4zOTMyNjcsLTEuNjU2OTEzIDcuODQyNzQ2LC0xLjk4OTgzIDEyLjE5MTgyNywtMC45MTIyMTEgOC40OTQ5NCwyLjEwNDg4MyAxNS4xNjEyMiw5LjE0NzIzNiAxNi45MjA4MiwxNy44NzUzOTcgMC4yNDI2NiwxLjIwMzY5OSAwLjI4MzUyLDEuNzg5NTAxIDAuMjg0MDEsNC4wNzI4OTggMy43ZS00LDEuNjU5NzcxIC0wLjA2MTMsMy4wMTgzNDYgLTAuMTYzMjMsMy41OTczMzUgLTAuMjM1NTEsMS4zMzc2MTEgLTAuODU2MjQsMy42OTc1MjQgLTEuMTA3ODMsNC4yMTE3NTYgbCAtMC4yMTUyNiwwLjQzOTk2OCAtMS40NTk5MSwwLjAzNDk2IGMgLTEuMTAzNDMsMC4wMjY0NCAtMS40NzE5NSwtMC4wMDM5IC0xLjUwOTE5LC0wLjEyNDA0NiB6IgogICAgICAgaWQ9InBhdGg0ODMiIC8+CiAgICA8cGF0aAogICAgICAgc3R5bGU9ImZpbGw6IzAwMDAwMDtzdHJva2Utd2lkdGg6MC4zMiIKICAgICAgIGlkPSJwYXRoMzQ1IgogICAgICAgZD0iIiAvPgogICAgPHBhdGgKICAgICAgIHN0eWxlPSJmaWxsOiMwMDAwMDA7c3Ryb2tlLXdpZHRoOjAuMzIiCiAgICAgICBpZD0icGF0aDExNyIKICAgICAgIGQ9IiIgLz4KICA8L2c+Cjwvc3ZnPgo="
+     ]
+    }
+   },
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "![Quantinuum%20Logos_primary_blue_small.svg](attachment:Quantinuum%20Logos_primary_blue_small.svg)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Using the Quantinuum Emulators via Azure Quantum and pytket-qsharp\n",
+    "\n",
+    "This notebook contains examples for running quantum circuits on Quantinuum's emulators via `pytket-qsharp`.\n",
+    "\n",
+    "An emulator can be used to get an idea of what a quantum device will output for our quantum circuit. This enables circuit debugging and optimization before running on a physical machine. Emulators differ from simulators in that they model the physical and noise model of the device whereas simulators may model noise parameters, but not physical parameters. The Quantinuum emulators run on a physical noise model of the Quantinuum H-Series devices. There are various noise/error parameters modeled. For detailed information on the noise model, see the *Quantinuum System Model H1 Emulator Product Data Sheet* at [Quantinuum H-series](https://www.quantinuum.com/products/h1).\n",
+    "\n",
+    "There are a few options for using the emulators: \n",
+    "\n",
+    "1. **Basic Usage:** Use the emulator as provided, which represents both the physical operations in the device as well as the noise. This the most common and simplest way to use the emulator. \n",
+    "2. **Noiseless Emulation:** Use the emulator without the physical noise model applied. The physical device operations are represented, but all errors are set to 0. \n",
+    "3. **Noise Parameters (*advanced option*):** Experiment with the noise parameters in the emulator. There is no guarantee that results achieved changing these parameters will represent outputs from the actual quantum computer represented.\n",
+    "4. **Stabilizer Emulator:** Use of the emulator for circuits involving only Clifford operations. \n",
+    "\n",
+    "For more information, see the *Quantinuum System Model H1 Emulator Product Data Sheet* at [Quantinuum H-series](https://www.quantinuum.com/products/h1) for detailed information on each of the emulators available and the full list of options available.\n",
+    "\n",
+    "**Emulator Usage:**\n",
+    "* [Basic Usage](#basic-usage)\n",
+    "* [Noiseless Emulation](#no-noise)\n",
+    "* [Noise Parameters (*advanced*)](#noise)\n",
+    "* [Stabilizer Emulator](#stabilizer)"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Installations <a class=\"anchor\" id=\"installations\"></a>\n",
+    "\n",
+    "In order to run this notebook, you'll need to install a few packages into your local environment related to the [Microsoft QDK](https://learn.microsoft.com/en-us/azure/quantum/install-overview-qdk?tabs=tabid-vscode%2Ctabid-conda). For additional information or troubleshooting with the following installations, see: [Use Q# and Python with Jupyter Notebooks](https://learn.microsoft.com/en-us/azure/quantum/install-overview-qdk?tabs=tabid-vscode%2Ctabid-dotnetcli#use-q-and-python-with-jupyter-notebooks). If you prefer to use VS Code instead of Jupyter notebooks, see: [Using the Microsoft QDK with VS Code](https://learn.microsoft.com/en-us/azure/quantum/install-overview-qdk?tabs=tabid-vscode%2Ctabid-dotnetcli#use-q-and-python-with-visual-studio-and-visual-studio-code).\n",
+    "\n",
+    "1. Install the [.NET SDK](https://dotnet.microsoft.com/en-us/download). Make note of what version is recommended with the Microsoft QDK here: [Use Q# and Python with Jupyter Notebooks](https://learn.microsoft.com/en-us/azure/quantum/install-overview-qdk?tabs=tabid-vscode%2Ctabid-dotnetcli#use-q-and-python-with-jupyter-notebooks).\n",
+    "1. Install the `qsharp` python package: `pip install qsharp`.\n",
+    "1. Run `dotnet tool install -g Microsoft.Quantum.IQSharp` in a CLI after .NET is installed.\n",
+    "1. Run `dotnet iqsharp install`.\n",
+    "1. Install the `azure-quantum` python package: `pip install azure-quantum`.\n",
+    "1. Install [pytket-qsharp](https://cqcl.github.io/pytket-qsharp/api/api.html): `pip install pytket-qsharp`."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Emulator Usage"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Basic Usage <a class=\"anchor\" id=\"basic-usage\"></a>\n",
+    "\n",
+    "This section covers usage of the emulator which represents a physical and noise model of the device being used. For example, if using the `quantinuum.sim.h1-1e` target, this emulates the H1-1 quantum computer.\n",
+    "\n",
+    "Here the circuit is created via the pytket python library. For details on getting started with `pytket`, see pytket's [Getting Started](https://cqcl.github.io/tket/pytket/api/getting_started.html) page."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "\n",
+       "\n",
+       "\n",
+       "\n",
+       "\n",
+       "<iframe srcdoc=\"\n",
+       "&lt;!DOCTYPE html&gt;\n",
+       "&lt;html lang=&#34;en&#34;&gt;\n",
+       "&lt;head&gt;\n",
+       "    &lt;meta charset=&#34;UTF-8&#34;&gt;\n",
+       "    &lt;script type=&#34;application/javascript&#34; src=&#34;https://cdn.jsdelivr.net/npm/vue@3&#34;&gt;&lt;/script&gt;\n",
+       "    &lt;script type=&#34;application/javascript&#34; src=&#34;https://unpkg.com/pytket-circuit-renderer@0.3/dist/pytket-circuit-renderer.umd.js&#34;&gt;&lt;/script&gt;\n",
+       "    &lt;link rel=&#34;stylesheet&#34; href=&#34;https://unpkg.com/pytket-circuit-renderer@0.3/dist/pytket-circuit-renderer.css&#34;&gt;\n",
+       "&lt;/head&gt;\n",
+       "&lt;body&gt;\n",
+       "    &lt;div id=&#34;circuit-display-vue-container-c9432f4b-0a20-441a-8497-a94dbd733524&#34; class=&#34;pytket-circuit-display-container&#34;&gt;\n",
+       "        &lt;div style=&#34;display: none&#34;&gt;\n",
+       "            &lt;div id=&#34;circuit-json-to-display&#34;&gt;{&#34;bits&#34;: [[&#34;c&#34;, [0]], [&#34;c&#34;, [1]]], &#34;commands&#34;: [{&#34;args&#34;: [[&#34;q&#34;, [0]]], &#34;op&#34;: {&#34;type&#34;: &#34;H&#34;}}, {&#34;args&#34;: [[&#34;q&#34;, [0]], [&#34;q&#34;, [1]]], &#34;op&#34;: {&#34;type&#34;: &#34;CX&#34;}}, {&#34;args&#34;: [[&#34;q&#34;, [0]], [&#34;c&#34;, [0]]], &#34;op&#34;: {&#34;type&#34;: &#34;Measure&#34;}}, {&#34;args&#34;: [[&#34;q&#34;, [1]], [&#34;c&#34;, [1]]], &#34;op&#34;: {&#34;type&#34;: &#34;Measure&#34;}}], &#34;created_qubits&#34;: [], &#34;discarded_qubits&#34;: [], &#34;implicit_permutation&#34;: [[[&#34;q&#34;, [0]], [&#34;q&#34;, [0]]], [[&#34;q&#34;, [1]], [&#34;q&#34;, [1]]]], &#34;name&#34;: &#34;Bell Test&#34;, &#34;phase&#34;: &#34;0.0&#34;, &#34;qubits&#34;: [[&#34;q&#34;, [0]], [&#34;q&#34;, [1]]]}&lt;/div&gt;\n",
+       "        &lt;/div&gt;\n",
+       "        &lt;circuit-display-container :circuit-element-str=&#34;&#39;#circuit-json-to-display&#39;&#34;&gt;&lt;/circuit-display-container&gt;\n",
+       "    &lt;/div&gt;\n",
+       "    &lt;script type=&#34;application/javascript&#34;&gt;\n",
+       "        const { createApp } = Vue;\n",
+       "        const circuitDisplayContainer = window[&#34;pytket-circuit-renderer&#34;].default;\n",
+       "        // Init variables to be shared between circuit display instances\n",
+       "        if (typeof window.pytketCircuitDisplays === &#34;undefined&#34;) {\n",
+       "            window.pytketCircuitDisplays = {};\n",
+       "        }\n",
+       "        const uid = &#34;c9432f4b-0a20-441a-8497-a94dbd733524&#34;;\n",
+       "        // Create the root Vue component\n",
+       "        const app = createApp({\n",
+       "            delimiters: [&#39;[[#&#39;, &#39;#]]&#39;],\n",
+       "            components: { circuitDisplayContainer },\n",
+       "        })\n",
+       "        app.config.unwrapInjectedRef = true;\n",
+       "        app.mount(&#34;#circuit-display-vue-container-&#34;+uid);\n",
+       "        window.pytketCircuitDisplays[uid] = app;\n",
+       "    &lt;/script&gt;\n",
+       "&lt;/body&gt;\n",
+       "&lt;/html&gt;\n",
+       "\"\n",
+       "        width=\"100%\" height=\"200px\"\n",
+       "        style=\"border: none; outline: none; resize: vertical; overflow: auto\"></iframe>\n",
+       "\n"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "from pytket.circuit import Circuit\n",
+    "from pytket.circuit.display import render_circuit_jupyter\n",
+    "\n",
+    "# Set up Bell Test\n",
+    "circuit = Circuit(2, name=\"Bell Test\")\n",
+    "circuit.H(0)\n",
+    "circuit.CX(0, 1)\n",
+    "circuit.measure_all()\n",
+    "\n",
+    "render_circuit_jupyter(circuit)"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Select the emulation device. See the Azure Quantum [Quantinuum Provider](https://learn.microsoft.com/en-us/azure/quantum/provider-quantinuum) for information and target names for each of the H-Series systems available. The devices available to you will be listed under **Providers &rarr; Quantinuum** on the Azure portal.\n",
+    "\n",
+    "You will find the Resource ID and Location in the **Overview** tab in the Azure portal quantum workspace.\n",
+    "\n",
+    "Select a machine target and login to the Quantinuum API using your credentials. You will be prompted to login to your Azure Quantum account. For more information on the `AzureBackend`, see the pytket-qsharp [AzureBackend API](https://cqcl.github.io/pytket-qsharp/api/api.html#pytket.extensions.qsharp.AzureBackend)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/x-qsharp-data": "\"Connecting to Azure Quantum...\"",
+      "text/plain": [
+       "Connecting to Azure Quantum..."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Connected to Azure Quantum workspace megan-qtm-test-aq in location eastus.\n",
+      "Loading package Microsoft.Quantum.Providers.Honeywell and dependencies...\n",
+      "Active target is now quantinuum.sim.h1-2e\n"
+     ]
+    }
+   ],
+   "source": [
+    "from pytket.extensions.qsharp import AzureBackend\n",
+    "\n",
+    "machine = 'quantinuum.sim.h1-2e'\n",
+    "resource_id = '/subscriptions/your-id'\n",
+    "location = 'your-location'\n",
+    "backend = AzureBackend(target_name=machine, resourceId=resource_id, location=location)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Compile the circuit to the Quantinuum backend with `get_compiled_circuit`. See the `pytket` [User Manual](https://cqcl.github.io/pytket/manual/index.html) for more information on all the options that are available."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "\n",
+       "\n",
+       "\n",
+       "\n",
+       "\n",
+       "<iframe srcdoc=\"\n",
+       "&lt;!DOCTYPE html&gt;\n",
+       "&lt;html lang=&#34;en&#34;&gt;\n",
+       "&lt;head&gt;\n",
+       "    &lt;meta charset=&#34;UTF-8&#34;&gt;\n",
+       "    &lt;script type=&#34;application/javascript&#34; src=&#34;https://cdn.jsdelivr.net/npm/vue@3&#34;&gt;&lt;/script&gt;\n",
+       "    &lt;script type=&#34;application/javascript&#34; src=&#34;https://unpkg.com/pytket-circuit-renderer@0.3/dist/pytket-circuit-renderer.umd.js&#34;&gt;&lt;/script&gt;\n",
+       "    &lt;link rel=&#34;stylesheet&#34; href=&#34;https://unpkg.com/pytket-circuit-renderer@0.3/dist/pytket-circuit-renderer.css&#34;&gt;\n",
+       "&lt;/head&gt;\n",
+       "&lt;body&gt;\n",
+       "    &lt;div id=&#34;circuit-display-vue-container-3bbb64f3-c7dc-4d7c-a7d9-67a4b0b7a47e&#34; class=&#34;pytket-circuit-display-container&#34;&gt;\n",
+       "        &lt;div style=&#34;display: none&#34;&gt;\n",
+       "            &lt;div id=&#34;circuit-json-to-display&#34;&gt;{&#34;bits&#34;: [[&#34;c&#34;, [0]], [&#34;c&#34;, [1]]], &#34;commands&#34;: [{&#34;args&#34;: [[&#34;q&#34;, [0]]], &#34;op&#34;: {&#34;params&#34;: [&#34;1/2&#34;], &#34;type&#34;: &#34;Rx&#34;}}, {&#34;args&#34;: [[&#34;q&#34;, [0]]], &#34;op&#34;: {&#34;params&#34;: [&#34;1/2&#34;], &#34;type&#34;: &#34;Rz&#34;}}, {&#34;args&#34;: [[&#34;q&#34;, [0]], [&#34;q&#34;, [1]]], &#34;op&#34;: {&#34;type&#34;: &#34;CX&#34;}}, {&#34;args&#34;: [[&#34;q&#34;, [0]], [&#34;c&#34;, [0]]], &#34;op&#34;: {&#34;type&#34;: &#34;Measure&#34;}}, {&#34;args&#34;: [[&#34;q&#34;, [1]], [&#34;c&#34;, [1]]], &#34;op&#34;: {&#34;type&#34;: &#34;Measure&#34;}}], &#34;created_qubits&#34;: [[&#34;q&#34;, [0]], [&#34;q&#34;, [1]]], &#34;discarded_qubits&#34;: [], &#34;implicit_permutation&#34;: [[[&#34;q&#34;, [0]], [&#34;q&#34;, [0]]], [[&#34;q&#34;, [1]], [&#34;q&#34;, [1]]]], &#34;name&#34;: &#34;Bell Test&#34;, &#34;phase&#34;: &#34;0.5&#34;, &#34;qubits&#34;: [[&#34;q&#34;, [0]], [&#34;q&#34;, [1]]]}&lt;/div&gt;\n",
+       "        &lt;/div&gt;\n",
+       "        &lt;circuit-display-container :circuit-element-str=&#34;&#39;#circuit-json-to-display&#39;&#34;&gt;&lt;/circuit-display-container&gt;\n",
+       "    &lt;/div&gt;\n",
+       "    &lt;script type=&#34;application/javascript&#34;&gt;\n",
+       "        const { createApp } = Vue;\n",
+       "        const circuitDisplayContainer = window[&#34;pytket-circuit-renderer&#34;].default;\n",
+       "        // Init variables to be shared between circuit display instances\n",
+       "        if (typeof window.pytketCircuitDisplays === &#34;undefined&#34;) {\n",
+       "            window.pytketCircuitDisplays = {};\n",
+       "        }\n",
+       "        const uid = &#34;3bbb64f3-c7dc-4d7c-a7d9-67a4b0b7a47e&#34;;\n",
+       "        // Create the root Vue component\n",
+       "        const app = createApp({\n",
+       "            delimiters: [&#39;[[#&#39;, &#39;#]]&#39;],\n",
+       "            components: { circuitDisplayContainer },\n",
+       "        })\n",
+       "        app.config.unwrapInjectedRef = true;\n",
+       "        app.mount(&#34;#circuit-display-vue-container-&#34;+uid);\n",
+       "        window.pytketCircuitDisplays[uid] = app;\n",
+       "    &lt;/script&gt;\n",
+       "&lt;/body&gt;\n",
+       "&lt;/html&gt;\n",
+       "\"\n",
+       "        width=\"100%\" height=\"200px\"\n",
+       "        style=\"border: none; outline: none; resize: vertical; overflow: auto\"></iframe>\n",
+       "\n"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "compiled_circuit = backend.get_compiled_circuit(circuit, optimisation_level=1)\n",
+    "\n",
+    "render_circuit_jupyter(compiled_circuit)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Run the circuit on the emulator chosen."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Loading package Microsoft.Quantum.Providers.Honeywell and dependencies...\n",
+      "Active target is now quantinuum.sim.h1-2e\n",
+      "Submitting TketCircuit to target quantinuum.sim.h1-2e...\n",
+      "Job successfully submitted.\n",
+      "   Job name: Bell Test\n",
+      "   Job ID: 50974a99-eff2-4bab-ba72-37f068759c57\n",
+      "('50974a99-eff2-4bab-ba72-37f068759c57', 100, 'null')\n"
+     ]
+    }
+   ],
+   "source": [
+    "n_shots = 100\n",
+    "handle = backend.process_circuit(compiled_circuit, \n",
+    "                                 n_shots=n_shots)\n",
+    "print(handle)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Check the job status."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CircuitStatus(status=<StatusEnum.SUBMITTED: 'Circuit has been submitted.'>, message=\"{'id': '50974a99-eff2-4bab-ba72-37f068759c57', 'name': 'Bell Test', 'status': 'Waiting', 'uri': 'https://portal.azure.com/#@microsoft.onmicrosoft.com/resource/subscriptions/f265e1a6-e359-4fca-842d-f90ecb910903/resourceGroups/QTM-Tests/providers/Microsoft.Quantum/Workspaces/megan-qtm-test-aq/job_management?microsoft_azure_quantum_jobid=50974a99-eff2-4bab-ba72-37f068759c57', 'provider': 'quantinuum', 'target': 'quantinuum.sim.h1-2e', 'creation_time': '2023-02-10T22:54:23.0154322+00:00', 'begin_execution_time': None, 'end_execution_time': None, 'cost_estimate': ''}\", error_detail=None, completed_time=None, queued_time=None, submitted_time=None, running_time=None, cancelled_time=None, error_time=None, queue_position=None)\n"
+     ]
+    }
+   ],
+   "source": [
+    "status = backend.circuit_status(handle)\n",
+    "print(status)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Once a job's status returns completed, return results with the `get_result` function."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "BackendResult(q_bits={},c_bits={c[0]: 0, c[1]: 1},counts=Counter({OutcomeArray([[192]], dtype=uint8): 50, OutcomeArray([[0]], dtype=uint8): 49, OutcomeArray([[64]], dtype=uint8): 1}),shots=None,state=None,unitary=None,density_matrix=None)"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "result = backend.get_result(handle)\n",
+    "\n",
+    "result"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Save jobs results."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import json\n",
+    "\n",
+    "with open('pytket_emulator_example.json', 'w') as file:\n",
+    "    json.dump(result.to_dict(), file)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The result output is just like that of a quantum device. The simulation by default runs with noise."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{(0, 0): 0.49, (1, 1): 0.5, (0, 1): 0.01}\n"
+     ]
+    }
+   ],
+   "source": [
+    "result = backend.get_result(handle)\n",
+    "print(result.get_distribution())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Counter({(1, 1): 50, (0, 0): 49, (0, 1): 1})\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(result.get_counts())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Noiseless Emulation <a class=\"anchor\" id=\"no-noise\"></a>\n",
+    "\n",
+    "The Quantinuum emulators may be run with or without the physical device's noise model. The default is the emulator runs with the physical noise model turned on. The physical noise model can be turned off by setting `noisy_simulation=False`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Loading package Microsoft.Quantum.Providers.Honeywell and dependencies...\n",
+      "Active target is now quantinuum.sim.h1-2e\n",
+      "Submitting TketCircuit to target quantinuum.sim.h1-2e...\n",
+      "Job successfully submitted.\n",
+      "   Job name: Bell Test\n",
+      "   Job ID: 7b2f42c6-3378-43ce-a9be-63d1fcd72188\n",
+      "('7b2f42c6-3378-43ce-a9be-63d1fcd72188', 100, 'null')\n"
+     ]
+    }
+   ],
+   "source": [
+    "n_shots = 100\n",
+    "no_error_model_handle = backend.process_circuit(compiled_circuit, \n",
+    "                                                n_shots=n_shots,\n",
+    "                                                noisy_simulation=False)\n",
+    "print(no_error_model_handle)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CircuitStatus(status=<StatusEnum.SUBMITTED: 'Circuit has been submitted.'>, message=\"{'id': '7b2f42c6-3378-43ce-a9be-63d1fcd72188', 'name': 'Bell Test', 'status': 'Waiting', 'uri': 'https://portal.azure.com/#@microsoft.onmicrosoft.com/resource/subscriptions/f265e1a6-e359-4fca-842d-f90ecb910903/resourceGroups/QTM-Tests/providers/Microsoft.Quantum/Workspaces/megan-qtm-test-aq/job_management?microsoft_azure_quantum_jobid=7b2f42c6-3378-43ce-a9be-63d1fcd72188', 'provider': 'quantinuum', 'target': 'quantinuum.sim.h1-2e', 'creation_time': '2023-02-10T22:55:16.8659409+00:00', 'begin_execution_time': None, 'end_execution_time': None, 'cost_estimate': ''}\", error_detail=None, completed_time=None, queued_time=None, submitted_time=None, running_time=None, cancelled_time=None, error_time=None, queue_position=None)\n"
+     ]
+    }
+   ],
+   "source": [
+    "no_error_model_status = backend.circuit_status(no_error_model_handle)\n",
+    "print(no_error_model_status)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "BackendResult(q_bits={},c_bits={c[0]: 0, c[1]: 1},counts=Counter({OutcomeArray([[192]], dtype=uint8): 57, OutcomeArray([[0]], dtype=uint8): 41, OutcomeArray([[128]], dtype=uint8): 1, OutcomeArray([[64]], dtype=uint8): 1}),shots=None,state=None,unitary=None,density_matrix=None)"
+      ]
+     },
+     "execution_count": 13,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "no_error_model_result = backend.get_result(no_error_model_handle)\n",
+    "\n",
+    "no_error_model_result"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "with open('pytket_emulator_noiseless_example.json', 'w') as file:\n",
+    "    json.dump(result.to_dict(), file)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{(1, 1): 0.57, (0, 0): 0.41, (1, 0): 0.01, (0, 1): 0.01}\n",
+      "Counter({(1, 1): 57, (0, 0): 41, (1, 0): 1, (0, 1): 1})\n"
+     ]
+    }
+   ],
+   "source": [
+    "no_error_model_result = backend.get_result(no_error_model_handle)\n",
+    "print(no_error_model_result.get_distribution())\n",
+    "\n",
+    "print(no_error_model_result.get_counts())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Noise Parameters <a class=\"anchor\" id=\"noise\"></a>\n",
+    "\n",
+    "The emulator runs with default error parameters that represent a noise environment similar to the physical devices. The `error-params` option can be used to override these error parameters and do finer-grain tweaks of the error model. For detailed information on the noise model, see the *Quantinuum System Model H1 Emulator Product Data Sheet* at [Quantinuum System Model H1](https://www.quantinuum.com/hardware/h1).\n",
+    "\n",
+    "In this section, examples are given for experimenting with the noise and error parameters of the emulators. These are advanced options and not recommended to start with when doing initial experiments. As mentioned above, there is no guarantee that results achieved changing these parameters will represent outputs from the actual quantum computer represented. \n",
+    "\n",
+    "**Note**: All the noise parameters are used together any time a simulation is run. If only some of the parameters are specified, the rest of the parameters are used at their default settings. The parameters to override are specified with the `options` parameter.\n",
+    "\n",
+    "* [Physical Noise](#physical-noise)\n",
+    "* [Dephasing Noise](#dephasing-noise)\n",
+    "* [Arbitrary Angle Noise Scaling](#arbitrary-angle-noise)\n",
+    "* [Scaling](#scaling)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Physical Noise <a class=\"anchor\" id=\"physical-noise\"></a>\n",
+    "\n",
+    "See the *Quantinuum System Model H1 Emulator Product Data Sheet* at [Quantinuum System Model H1](https://www.quantinuum.com/hardware/h1) for information on these parameters."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Loading package Microsoft.Quantum.Providers.Honeywell and dependencies...\n",
+      "Active target is now quantinuum.sim.h1-2e\n",
+      "Submitting TketCircuit to target quantinuum.sim.h1-2e...\n",
+      "Job successfully submitted.\n",
+      "   Job name: Bell Test\n",
+      "   Job ID: a4c10a1e-1ecb-4320-ac69-04a4c06ec4fa\n"
+     ]
+    }
+   ],
+   "source": [
+    "handle = backend.process_circuit(compiled_circuit, \n",
+    "                                 n_shots=100, \n",
+    "                                 request_options={\n",
+    "                                     \"options\": {\n",
+    "                                         'error-params': {\n",
+    "                                             'p1': 4e-5,\n",
+    "                                             'p2': 3e-3,\n",
+    "                                             'p_meas': 3e-3,\n",
+    "                                             'p_init': 4e-5,\n",
+    "                                             'p_crosstalk_meas': 1e-5,\n",
+    "                                             'p_crosstalk_init': 3e-5,\n",
+    "                                             'p1_emission': 6e-6,\n",
+    "                                             'p2_emission': 2e-4\n",
+    "                                         }\n",
+    "                                     }})"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{(0, 0): 0.5, (1, 1): 0.5}\n"
+     ]
+    }
+   ],
+   "source": [
+    "result = backend.get_result(handle)\n",
+    "\n",
+    "print(result.get_distribution())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Dephasing Noise <a class=\"anchor\" id=\"dephasing-noise\"></a>\n",
+    "\n",
+    "See the *Quantinuum System Model H1 Emulator Product Data Sheet* at [Quantinuum System Model H1](https://www.quantinuum.com/hardware/h1) for information on these parameters."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Loading package Microsoft.Quantum.Providers.Honeywell and dependencies...\n",
+      "Active target is now quantinuum.sim.h1-2e\n",
+      "Submitting TketCircuit to target quantinuum.sim.h1-2e...\n",
+      "Job successfully submitted.\n",
+      "   Job name: Bell Test\n",
+      "   Job ID: 2a1213ed-16c1-4fad-ae62-bba6dc26f679\n"
+     ]
+    }
+   ],
+   "source": [
+    "handle = backend.process_circuit(compiled_circuit, \n",
+    "                                 n_shots=100, \n",
+    "                                 request_options={\n",
+    "                                     \"options\": {\n",
+    "                                         'error-params': {\n",
+    "                                             'coherent_dephasing_rate': 0.2,\n",
+    "                                             'incoherent_dephasing_rate': 0.3,\n",
+    "                                             'coherent_dephasing': False,  # False => run the incoherent noise model\n",
+    "                                             'transport_dephasing': False, # False => turn off transport dephasing error\n",
+    "                                             'idle_dephasing': False # False => turn off idel dephasing error\n",
+    "                                         },\n",
+    "                                     }})"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{(0, 0): 0.37, (1, 1): 0.61, (1, 0): 0.02}\n"
+     ]
+    }
+   ],
+   "source": [
+    "result = backend.get_result(handle)\n",
+    "\n",
+    "print(result.get_distribution())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Arbitrary Angle Noise Scaling <a class=\"anchor\" id=\"arbitrary-angle-noise\"></a>\n",
+    "\n",
+    "See the *Quantinuum System Model H1 Emulator Product Data Sheet* at [Quantinuum System Model H1](https://www.quantinuum.com/hardware/h1) for information on these parameters."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Loading package Microsoft.Quantum.Providers.Honeywell and dependencies...\n",
+      "Active target is now quantinuum.sim.h1-2e\n",
+      "Submitting TketCircuit to target quantinuum.sim.h1-2e...\n",
+      "Job successfully submitted.\n",
+      "   Job name: Bell Test\n",
+      "   Job ID: bf638692-b4c8-47e8-baa0-5c2c50480593\n"
+     ]
+    }
+   ],
+   "source": [
+    "handle = backend.process_circuit(compiled_circuit, \n",
+    "                                 n_shots=100, \n",
+    "                                 request_options={\n",
+    "                                     \"options\": {\n",
+    "                                         'error-params': {\n",
+    "                                             'przz_a': 1.09,\n",
+    "                                             'przz_b': 0.051,\n",
+    "                                             'przz_c': 1.365,\n",
+    "                                             'przz_d': 0.035 \n",
+    "                                         },\n",
+    "                                     }})"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{(1, 1): 0.5, (0, 0): 0.5}\n"
+     ]
+    }
+   ],
+   "source": [
+    "result = backend.get_result(handle)\n",
+    "\n",
+    "print(result.get_distribution())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Scaling <a class=\"anchor\" id=\"scaling\"></a>\n",
+    "\n",
+    "All the error rates can be scaled linearly using the `scale` parameter. See the *Quantinuum System Model H1 Emulator Product Data Sheet* at [Quantinuum System Model H1](https://www.quantinuum.com/hardware/h1) for information on these parameters."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Loading package Microsoft.Quantum.Providers.Honeywell and dependencies...\n",
+      "Active target is now quantinuum.sim.h1-2e\n",
+      "Submitting TketCircuit to target quantinuum.sim.h1-2e...\n",
+      "Job successfully submitted.\n",
+      "   Job name: Bell Test\n",
+      "   Job ID: 284d7112-bea7-4662-ac2c-bd93a6902db7\n"
+     ]
+    }
+   ],
+   "source": [
+    "handle = backend.process_circuit(compiled_circuit, \n",
+    "                                 n_shots=100, \n",
+    "                                 request_options={\n",
+    "                                     \"options\": { \n",
+    "                                         'error-params': {\n",
+    "                                             'scale': 0.1,  # scale error rates linearly by 0.1\n",
+    "                                         },\n",
+    "                                     }})"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{(1, 1): 0.44, (0, 0): 0.56}\n"
+     ]
+    }
+   ],
+   "source": [
+    "result = backend.get_result(handle)\n",
+    "\n",
+    "print(result.get_distribution())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Other aspects of the noise model can scale specific error rates in the error model, which are modeled here."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Loading package Microsoft.Quantum.Providers.Honeywell and dependencies...\n",
+      "Active target is now quantinuum.sim.h1-2e\n",
+      "Submitting TketCircuit to target quantinuum.sim.h1-2e...\n",
+      "Job successfully submitted.\n",
+      "   Job name: Bell Test\n",
+      "   Job ID: 75c89b57-56b9-4b29-b466-edb6aadebcbd\n"
+     ]
+    }
+   ],
+   "source": [
+    "handle = backend.process_circuit(compiled_circuit, \n",
+    "                                 n_shots=100, \n",
+    "                                 request_options={\n",
+    "                                     \"options\": {\n",
+    "                                         'error-params': {\n",
+    "                                             'p1_scale': 0.1,\n",
+    "                                             'p2_scale': 0.1,\n",
+    "                                             'meas_scale': 0.1,\n",
+    "                                             'init_scale': 0.1,\n",
+    "                                             'memory_scale': 0.1,\n",
+    "                                             'emission_scale': 0.1,\n",
+    "                                             'crosstalk_scale': 0.1,\n",
+    "                                             'leakage_scale': 0.1\n",
+    "                                         },\n",
+    "                                     }})"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 25,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{(1, 1): 0.5, (0, 0): 0.5}\n"
+     ]
+    }
+   ],
+   "source": [
+    "result = backend.get_result(handle)\n",
+    "\n",
+    "print(result.get_distribution())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Stabilizer Emulator <a class=\"anchor\" id=\"stabilizer\"></a>\n",
+    "\n",
+    "By default, emulations are run using a state-vector emulator, which simulates any quantum operation. However, if the quantum operations are all Clifford gates, it can be faster for complex circuits to use the `stabilizer` emulator."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 28,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Loading package Microsoft.Quantum.Providers.Honeywell and dependencies...\n",
+      "Active target is now quantinuum.sim.h1-2e\n",
+      "Submitting TketCircuit to target quantinuum.sim.h1-2e...\n",
+      "Job successfully submitted.\n",
+      "   Job name: Bell Test\n",
+      "   Job ID: 2b171814-e634-40e9-b17f-75b50d7cbd59\n",
+      "('2b171814-e634-40e9-b17f-75b50d7cbd59', 100, 'null')\n"
+     ]
+    }
+   ],
+   "source": [
+    "n_shots = 100\n",
+    "handle = backend.process_circuit(compiled_circuit, \n",
+    "                                 n_shots=n_shots,\n",
+    "                                 request_options={\n",
+    "                                     \"options\": {\n",
+    "                                         'simulator': 'stabilizer',\n",
+    "                                     }})\n",
+    "print(handle)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 30,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "BackendResult(q_bits={},c_bits={c[0]: 0, c[1]: 1},counts=Counter({OutcomeArray([[0]], dtype=uint8): 57, OutcomeArray([[192]], dtype=uint8): 43}),shots=None,state=None,unitary=None,density_matrix=None)"
+      ]
+     },
+     "execution_count": 30,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "result = backend.get_result(handle)\n",
+    "\n",
+    "result"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "with open('pytket_emulator_stabilizer_example.json', 'w') as file:\n",
+    "    json.dump(result.to_dict(), file)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 31,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{(1, 1): 0.43, (0, 0): 0.57}\n",
+      "Counter({(0, 0): 57, (1, 1): 43})\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(result.get_distribution())\n",
+    "\n",
+    "print(result.get_counts())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Noiseless Stabilizer\n",
+    "\n",
+    "A noiseless stabilizer simulation can be specified via options in the `process_circuit` function with the following options:\n",
+    "\n",
+    "- `simulator`: choose to run with a `stabilizer` simulator or `state-vector` (default is `state-vector`)\n",
+    "- `error-model`: whether to run with or without the physical device noise model on or off. The default is `True`, which means the physical noise model is turned on. If set to `False`, the physical noise model is turned off, performing noiseless simulation."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 33,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Loading package Microsoft.Quantum.Providers.Honeywell and dependencies...\n",
+      "Active target is now quantinuum.sim.h1-2e\n",
+      "Submitting TketCircuit to target quantinuum.sim.h1-2e...\n",
+      "Job successfully submitted.\n",
+      "   Job name: Bell Test\n",
+      "   Job ID: fb178a0c-c609-4944-af08-9658e175dc30\n"
+     ]
+    }
+   ],
+   "source": [
+    "handle = backend.process_circuit(compiled_circuit, \n",
+    "                                 n_shots=100, \n",
+    "                                 request_options={\n",
+    "                                     \"options\": {\n",
+    "                                         'simulator': 'stabilizer',\n",
+    "                                         'error-model': False,\n",
+    "                                     }})"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 34,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{(0, 0): 0.51, (1, 1): 0.48, (0, 1): 0.01}\n"
+     ]
+    }
+   ],
+   "source": [
+    "result = backend.get_result(handle)\n",
+    "\n",
+    "print(result.get_distribution())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<div align=\"center\"> &copy; 2023 by Quantinuum. All Rights Reserved. </div>"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.10"
+  },
+  "vscode": {
+   "interpreter": {
+    "hash": "c91c3faa82aad5b8fd8e5c246f2148b117d9b10fafcbd8b7de05f9480e768361"
+   }
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
Adding example so Microsoft users have means to submit + know how to do TKET compilation in stack and pass through emulator noise parameters.

Few questions:

1. Is the correct `get_compiled_circuit` function being used? I noted the default is `default_compilation_pass`, but will this take into account the backend being submitted to? so will it for sure be picking up on the Quantinuum passes?
2. Can you verify / check that the error parameters being passed through (for example `noisy_simulation=False` are actually passing through? Thoughts on this?
3. The Conditional Gates section in the basic submission notebook gave a `NoMidMeasurePredicate` error, which makes me think it is not picking up that the submission is to QTM and so is supported. Would like help / to fix that. 

Comments/Observations

- Batch Submission is not supported in the same way as it is in `pytket-quantinuum`, probably due to multiple backends being accessible via the same interface, but thought to mention it would be a nice functionality to have
- There is no cost function in the `AzureBackend` to view # of HQCs before users submit and Microsoft doesn't return this from the Syntax Checkers... not a hold-up but wanted to point this out. 