### PR TITLE
Remove constraints on mid-circuit measurement and classical control

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,6 +1,12 @@
 Changelog
 ~~~~~~~~~
 
+Unreleased
+----------
+
+* Remove constraints on mid-circuit measurement and classical control.
+* Update pytket version requirement to 1.20.
+
 0.35.0 (September 2023)
 -----------------------
 

--- a/pytket/extensions/qsharp/backends/common.py
+++ b/pytket/extensions/qsharp/backends/common.py
@@ -48,10 +48,7 @@ from pytket.passes import (
 from pytket.circuit_library import _TK1_to_RzRx
 from pytket.predicates import (
     GateSetPredicate,
-    NoClassicalControlPredicate,
-    NoFastFeedforwardPredicate,
     Predicate,
-    NoMidMeasurePredicate,
     NoSymbolsPredicate,
 )
 from pytket.architecture import Architecture

--- a/pytket/extensions/qsharp/backends/common.py
+++ b/pytket/extensions/qsharp/backends/common.py
@@ -64,10 +64,7 @@ if TYPE_CHECKING:
 
 def qs_predicates(gate_set: Set[OpType]) -> List[Predicate]:
     return [
-        NoMidMeasurePredicate(),
         NoSymbolsPredicate(),
-        NoClassicalControlPredicate(),
-        NoFastFeedforwardPredicate(),
         GateSetPredicate(gate_set),
     ]
 

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ setup(
     packages=find_namespace_packages(include=["pytket.*"]),
     include_package_data=True,
     install_requires=[
-        "pytket ~= 1.19",
+        "pytket ~= 1.20",
         "qsharp ~= 0.28.291394",
         "qsharp-core ~= 0.28.291394",
         "markdown",


### PR DESCRIPTION
Closes #47 .

Would have added a test but I couldn't find a device that was available and supported this (I know the Quantinuum device on Azure does).